### PR TITLE
Fix syntax error on line 1486 reported by Python 2.6.6

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1483,8 +1483,9 @@ class Mixpanel(object):
 
         """
         gzip_filename = filename + '.gz'
-        with open(filename, 'rb') as f_in, gzip.open(gzip_filename, 'wb') as f_out:
-            shutil.copyfileobj(f_in, f_out)
+        with open(filename, 'rb') as f_in:
+            gzip.open(gzip_filename, 'wb') as f_out:
+                shutil.copyfileobj(f_in, f_out)
 
     @staticmethod
     def _prep_event_for_import(event, token, timezone_offset):


### PR DESCRIPTION
Python 2.6.6 on Centos 6.8

Traceback (most recent call last):
  File "./people-delete.py", line 1, in <module>
    from mixpanel_api import Mixpanel
  File "/usr/lib/python2.6/site-packages/mixpanel_api/__init__.py", line 1486
    with open(filename, 'rb') as f_in, gzip.open(gzip_filename, 'wb') as f_out:
