### PR TITLE
epic: streaming pipelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,10 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Streaming dev files (local only)
+scratch-*.py
+SCRATCH_TEST_DATA/
+.vscode/
+.venv/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@
   - [Group Delete](#group-delete)
   - [Query JQL API](#query-the-jql-api)
   - [Import from Amplitude](#import-from-amplitude)
+- [Streaming import/export](#streaming-importexport)
+  - [Streaming installation](#streaming-installation)
+  - [Stream import events](#stream-import-events)
+  - [Stream import people](#stream-import-people)
+  - [Stream import groups](#stream-import-groups)
+  - [Stream export events](#stream-export-events)
+  - [Stream export people](#stream-export-people)
+  - [Stream export groups](#stream-export-groups)
+  - [Cross-project migration](#cross-project-migration)
+  - [Vendor migrations](#vendor-migrations)
+  - [Streaming options reference](#streaming-options-reference)
+- [CLI](#cli)
+  - [CLI examples](#cli-examples)
 - [Advanced scripting techniques](#advanced-scripting-techniques)
   - [Lambda functions](#lambda-functions)
 
@@ -43,6 +56,12 @@ You may install the mixpanel-utils module via pip:
 
 ```
 pip3 install mixpanel-utils
+```
+
+For high-volume streaming import/export and the `mixpanel-utils` CLI, install with the streaming extras:
+
+```
+pip3 install mixpanel-utils[streaming]
 ```
 
 #### Usage
@@ -451,6 +470,250 @@ Note:
 1. Start and end dates are in `YYYYMMDDTHH` format.
 2. start and end date are as per `server_upload_time` as per [Export API doc](https://www.docs.developers.amplitude.com/analytics/apis/export-api/?h=export#considerations).
 3. This script would be for projects on [Original ID Merge](https://docs.mixpanel.com/docs/tracking/how-tos/identifying-users#how-does-the-simplified-api-differ-from-the-original-api) only.
+
+#### Streaming import/export
+
+For high-volume imports, exports, and data migrations, use the async streaming interface via `mputils.stream`. It supports multiple file formats (JSONL, JSON, CSV, Parquet, gzip), cloud storage (GCS, S3), built-in vendor transforms, automatic data fixes, deduplication, and concurrent HTTP connections for maximum throughput.
+
+###### Streaming installation
+
+The streaming interface requires additional dependencies. Install them with:
+
+```
+pip3 install mixpanel-utils[streaming]           # core streaming
+pip3 install mixpanel-utils[streaming-gcs]       # + Google Cloud Storage support
+pip3 install mixpanel-utils[streaming-s3]        # + AWS S3 support
+pip3 install mixpanel-utils[streaming-all]       # everything
+```
+
+###### Stream import events
+
+```python
+await mputils.stream.import_events(data, options=None)
+```
+
+Example:
+
+```python
+import asyncio
+from mixpanel_utils import MixpanelUtils
+
+mputils = MixpanelUtils(
+	service_account_username='my-user.12345.mp-service-account',
+	service_account_password='ServiceAccountPasswordHere',
+	project_id=12345,
+	token='ProjectTokenHere',
+)
+
+result = asyncio.run(mputils.stream.import_events('./events.jsonl'))
+print(f"Imported {result['success']:,} events in {result['duration_human']}")
+```
+
+Imports events to Mixpanel at high throughput. The `data` parameter accepts a file path (JSONL, JSON, CSV, Parquet, or gzipped), a list of event dicts, an async iterator, or a cloud storage URL (`gs://bucket/path` or `s3://bucket/path`). The file format is auto-detected from the extension, or you can set it explicitly with the `stream_format` option. Returns a results dict with `total`, `success`, `failed`, `duration_human`, and other statistics.
+
+```python
+# Import with options
+result = asyncio.run(mputils.stream.import_events('./events.csv', {
+	'stream_format': 'csv',
+	'fix_data': True,
+	'dedupe': True,
+}))
+```
+
+###### Stream import people
+
+```python
+await mputils.stream.import_people(data, options=None)
+```
+
+Example:
+
+```python
+result = asyncio.run(mputils.stream.import_people('./profiles.jsonl'))
+```
+
+Imports user profiles to Mixpanel. Accepts the same `data` formats as `stream.import_events`. Profile data should include a `$distinct_id` and properties.
+
+###### Stream import groups
+
+```python
+await mputils.stream.import_groups(data, options=None)
+```
+
+Example:
+
+```python
+mputils.define_group_context(group_key='company_id')
+result = asyncio.run(mputils.stream.import_groups('./groups.jsonl'))
+```
+
+Imports group profiles to Mixpanel. Requires `group_key` to be set via `define_group_context` or at initialization.
+
+###### Stream export events
+
+```python
+await mputils.stream.export_events(filename=None, options=None)
+```
+
+Example:
+
+```python
+result = asyncio.run(mputils.stream.export_events('export.jsonl', {
+	'start': '2024-01-01',
+	'end': '2024-01-31',
+}))
+```
+
+Exports raw events from Mixpanel. Requires `start` and `end` dates in `YYYY-MM-DD` format. If `filename` is provided, events are written to that file. If `filename` is `None`, events are returned in memory. You can optionally pass a `where` clause for server-side filtering and a `limit` to cap the number of records.
+
+###### Stream export people
+
+```python
+await mputils.stream.export_people(folder=None, options=None)
+```
+
+Example:
+
+```python
+result = asyncio.run(mputils.stream.export_people('./people_export/'))
+```
+
+Exports user profiles from Mixpanel to the specified folder.
+
+###### Stream export groups
+
+```python
+await mputils.stream.export_groups(folder=None, options=None)
+```
+
+Example:
+
+```python
+mputils.define_group_context(data_group_id='123456789')
+result = asyncio.run(mputils.stream.export_groups('./group_export/'))
+```
+
+Exports group profiles from Mixpanel. Requires `data_group_id` to be set.
+
+###### Cross-project migration
+
+```python
+await mputils.stream.export_import_events(options=None)
+await mputils.stream.export_import_people(options=None)
+await mputils.stream.export_import_groups(options=None)
+```
+
+Example:
+
+```python
+# Export events from the current project and import them into another
+result = asyncio.run(mputils.stream.export_import_events({
+	'start': '2024-01-01',
+	'end': '2024-12-31',
+	'second_token': 'TARGET_PROJECT_TOKEN',
+}))
+print(f"Migrated {result['success']:,} events")
+```
+
+Exports data from the current project and re-imports it in a single operation. Use the `second_token` option to import into a different project. This works for events, user profiles, and group profiles. This is the simplest way to migrate data between Mixpanel projects.
+
+###### Vendor migrations
+
+```python
+result = asyncio.run(mputils.stream.import_events('./amplitude_export.json', {
+	'vendor': 'amplitude',
+}))
+```
+
+The `vendor` option applies vendor-specific field mapping and transformations so data from other analytics platforms can be imported directly into Mixpanel. Supported vendors:
+
+- `amplitude` — Amplitude event exports
+- `heap` — Heap event data
+- `ga4` — Google Analytics 4 exports
+- `posthog` — PostHog event data
+- `mparticle` — mParticle event data
+- `june` — June analytics data
+- `mixpanel` — Mixpanel's own export format (useful for re-importing)
+
+You can pass additional vendor-specific configuration with the `vendor_opts` option as a dict.
+
+###### Streaming options reference
+
+All `stream.*` methods accept an `options` dict. These are the most commonly used options:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `fix_data` | bool | `False` | Auto-fix common data issues (missing fields, type coercion) |
+| `dedupe` | bool | `False` | Remove duplicate records via content hashing |
+| `compress` | bool | `True` | Gzip compress HTTP requests |
+| `workers` | int | `10` | Number of concurrent HTTP connections |
+| `records_per_batch` | int | `2000` | Records per API batch |
+| `vendor` | str | `None` | Apply a vendor-specific transform |
+| `dry_run` | bool | `False` | Transform data without sending to Mixpanel |
+| `stream_format` | str | auto | Force input format: `json`, `jsonl`, `csv`, or `parquet` |
+| `strict` | bool | `True` | Validate data strictly before sending |
+| `region` | str | inherited | Data residency region (`US`, `EU`, or `IN`). Inherited from the parent `MixpanelUtils` instance by default |
+| `tags` | dict | `{}` | Properties to add to every record |
+| `aliases` | dict | `{}` | Rename property keys |
+| `scrub_props` | list | `[]` | Properties to remove from every record |
+| `fix_time` | bool | `False` | Normalize timestamps to UNIX epoch |
+| `flatten` | bool | `False` | Flatten nested properties |
+| `remove_nulls` | bool | `False` | Remove null/empty values |
+| `epoch_start` | int | `0` | Skip records before this UNIX timestamp |
+| `epoch_end` | int | `9991427224` | Skip records after this UNIX timestamp |
+| `event_whitelist` | list | `[]` | Only import these event names |
+| `event_blacklist` | list | `[]` | Skip these event names |
+
+#### CLI
+
+The `mixpanel-utils` command-line tool is installed alongside the streaming extras. It provides the same import, export, and migration functionality without writing any Python.
+
+```
+pip3 install mixpanel-utils[streaming]
+```
+
+Usage:
+
+```
+mixpanel-utils DATA --type TYPE --token TOKEN [options]
+```
+
+Run `mixpanel-utils --help` for the full list of options.
+
+###### CLI examples
+
+```bash
+# Import events from a JSONL file
+mixpanel-utils ./events.jsonl --type event --token YOUR_TOKEN
+
+# Import a CSV file (explicit format)
+mixpanel-utils ./data.csv --type event --token YOUR_TOKEN --format csv
+
+# Import from a cloud storage URL
+mixpanel-utils gs://my-bucket/events.json --type event --token YOUR_TOKEN
+
+# Import user profiles
+mixpanel-utils ./profiles.jsonl --type user --token YOUR_TOKEN
+
+# Export events to a file
+mixpanel-utils --type export --acct USER --pass PASS --project 12345 \
+    --start 2024-01-01 --end 2024-01-31
+
+# Export and re-import events to another project
+mixpanel-utils --type export-import-event --acct USER --pass PASS --project 12345 \
+    --start 2024-01-01 --end 2024-12-31 --second-token TARGET_TOKEN
+
+# Vendor migration (e.g., from Amplitude)
+mixpanel-utils ./amplitude_export.json --type event --token YOUR_TOKEN --vendor amplitude
+
+# Dry run (transform data without sending to Mixpanel)
+mixpanel-utils ./events.jsonl --type event --dry-run
+
+# Disable auto-fix
+mixpanel-utils ./events.jsonl --type event --token YOUR_TOKEN --no-fix
+```
+
+Authentication can also be provided via environment variables: `MP_PROJECT`, `MP_ACCT`, `MP_PASS`, `MP_TOKEN`, `MP_SECRET`.
 
 #### Advanced scripting techniques
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 testpaths = tests
 python_files = test_*.py
+asyncio_mode = auto

--- a/sample_scripts/README.md
+++ b/sample_scripts/README.md
@@ -7,3 +7,8 @@ General purpose scripts leveraging the Mixpanel python module for ETL workflows.
 
 ## Importing data
 - [Reading a folder containing compressed json files and importing them into a project](/sample_scripts/importing_from_large_compressed_json_files/)
+
+## Streaming import/export
+- [High-volume event import using streaming](/sample_scripts/streaming_import_events/)
+- [Cross-project migration (export & reimport)](/sample_scripts/streaming_export_and_reimport/)
+- [Migrating from another analytics vendor](/sample_scripts/streaming_vendor_migration/)

--- a/sample_scripts/streaming_export_and_reimport/README.md
+++ b/sample_scripts/streaming_export_and_reimport/README.md
@@ -1,0 +1,21 @@
+# Cross-project migration (export & reimport)
+
+This script demonstrates how to migrate data between Mixpanel projects using `mputils.stream.export_import_events`. It exports events from one project and re-imports them into another in a single operation — no intermediate files needed.
+
+Common use cases:
+
+- **Project consolidation** — Merge events from multiple projects into one
+- **Environment promotion** — Copy production data to a staging project
+- **Region migration** — Move data between US, EU, and IN residency regions
+
+The same pattern works for user profiles (`export_import_people`) and group profiles (`export_import_groups`).
+
+## Configuration
+
+Edit `main.py` with your source project credentials and the target project's token. Set the date range for the events you want to migrate.
+
+## Installation
+
+```
+pip3 install mixpanel-utils[streaming]
+```

--- a/sample_scripts/streaming_export_and_reimport/main.py
+++ b/sample_scripts/streaming_export_and_reimport/main.py
@@ -1,0 +1,43 @@
+import asyncio
+from mixpanel_utils import MixpanelUtils
+
+# ----- Configuration
+SOURCE_CREDENTIALS = {
+    "project_id": None,  # REQUIRED - source Mixpanel project ID
+    "service_account_username": "",  # REQUIRED - service account with access to source project
+    "service_account_password": "",  # REQUIRED - service account password
+}
+TARGET_TOKEN = ""  # REQUIRED - project token of the destination project
+DATE_RANGE = {
+    "start": "2024-01-01",  # export start date (YYYY-MM-DD)
+    "end": "2024-12-31",  # export end date (YYYY-MM-DD)
+}
+# ----- Configuration
+
+mputils = MixpanelUtils(
+    service_account_username=SOURCE_CREDENTIALS['service_account_username'],
+    service_account_password=SOURCE_CREDENTIALS['service_account_password'],
+    project_id=SOURCE_CREDENTIALS['project_id'],
+)
+
+
+async def main():
+    # Export events from source and import into target project
+    print(f"Migrating events from {DATE_RANGE['start']} to {DATE_RANGE['end']}...")
+    result = await mputils.stream.export_import_events({
+        'start': DATE_RANGE['start'],
+        'end': DATE_RANGE['end'],
+        'second_token': TARGET_TOKEN,
+    })
+
+    status = "PASS" if result.get('failed', 0) == 0 else "FAIL"
+    print(f"\n[{status}] Cross-project event migration")
+    print(f"  total: {result.get('total', 0):,}  success: {result.get('success', 0):,}  failed: {result.get('failed', 0):,}")
+    if result.get('duration_human'):
+        print(f"  duration: {result['duration_human']}")
+    if result.get('errors'):
+        for msg, count in result['errors'].items():
+            print(f"  error: {msg} (x{count})")
+
+
+asyncio.run(main())

--- a/sample_scripts/streaming_import_events/README.md
+++ b/sample_scripts/streaming_import_events/README.md
@@ -1,0 +1,20 @@
+# Streaming event import
+
+This script demonstrates high-volume event import using the async streaming interface (`mputils.stream.import_events`). Unlike the synchronous `import_events()` method, the streaming interface handles:
+
+- **Multiple file formats** — JSONL, JSON arrays, CSV, Parquet, and gzip-compressed files (auto-detected from extension)
+- **Cloud storage** — Import directly from `gs://` or `s3://` URLs
+- **Concurrent connections** — Sends batches in parallel for maximum throughput
+- **Built-in transforms** — Auto-fix data issues, deduplicate records, flatten nested properties, and more
+
+This is the recommended approach for importing large datasets (100K+ events) or building production data pipelines.
+
+## Configuration
+
+Edit the `CREDENTIALS` section in `main.py` with your Mixpanel service account credentials and project token. Set the `DATA_FILE` variable to the path of your event data file.
+
+## Installation
+
+```
+pip3 install mixpanel-utils[streaming]
+```

--- a/sample_scripts/streaming_import_events/main.py
+++ b/sample_scripts/streaming_import_events/main.py
@@ -1,0 +1,47 @@
+import asyncio
+from mixpanel_utils import MixpanelUtils
+
+# ----- Configuration
+DATA_FILE = './events.jsonl'  # supports .jsonl, .json, .csv, .parquet, .json.gz
+CREDENTIALS = {
+    "project_id": None,  # REQUIRED - your Mixpanel project ID
+    "service_account_username": "",  # REQUIRED - service account username
+    "service_account_password": "",  # REQUIRED - service account password
+    "token": "",  # REQUIRED - project token (for imports)
+}
+# ----- Configuration
+
+mputils = MixpanelUtils(
+    service_account_username=CREDENTIALS['service_account_username'],
+    service_account_password=CREDENTIALS['service_account_password'],
+    project_id=CREDENTIALS['project_id'],
+    token=CREDENTIALS['token'],
+)
+
+
+async def main():
+    # Basic import — format is auto-detected from file extension
+    result = await mputils.stream.import_events(DATA_FILE)
+    print_result("Basic import", result)
+
+    # Import with transforms — fix data issues and deduplicate
+    result = await mputils.stream.import_events(DATA_FILE, {
+        'fix_data': True,
+        'dedupe': True,
+        'workers': 10,
+    })
+    print_result("Import with transforms", result)
+
+
+def print_result(label, result):
+    status = "PASS" if result.get('failed', 0) == 0 else "FAIL"
+    print(f"\n[{status}] {label}")
+    print(f"  total: {result.get('total', 0):,}  success: {result.get('success', 0):,}  failed: {result.get('failed', 0):,}")
+    if result.get('duration_human'):
+        print(f"  duration: {result['duration_human']}  requests: {result.get('requests', 0):,}")
+    if result.get('errors'):
+        for msg, count in result['errors'].items():
+            print(f"  error: {msg} (x{count})")
+
+
+asyncio.run(main())

--- a/sample_scripts/streaming_vendor_migration/README.md
+++ b/sample_scripts/streaming_vendor_migration/README.md
@@ -1,0 +1,23 @@
+# Migrating from another analytics vendor
+
+This script demonstrates how to import event data exported from another analytics platform into Mixpanel using the `vendor` option. The streaming interface automatically maps vendor-specific fields (event names, property names, timestamps, user IDs) to Mixpanel's format.
+
+Supported vendors:
+
+- **Amplitude** — Amplitude event exports
+- **Heap** — Heap event data
+- **GA4** — Google Analytics 4 BigQuery exports
+- **PostHog** — PostHog event data
+- **mParticle** — mParticle event data
+- **June** — June analytics data
+- **Mixpanel** — Mixpanel's own export format (useful for re-importing exported data)
+
+## Configuration
+
+Edit `main.py` with your Mixpanel credentials, the path to your vendor export file, and the vendor name. Optionally configure `VENDOR_OPTIONS` for vendor-specific settings.
+
+## Installation
+
+```
+pip3 install mixpanel-utils[streaming]
+```

--- a/sample_scripts/streaming_vendor_migration/main.py
+++ b/sample_scripts/streaming_vendor_migration/main.py
@@ -1,0 +1,42 @@
+import asyncio
+from mixpanel_utils import MixpanelUtils
+
+# ----- Configuration
+DATA_FILE = './amplitude_export.json'  # path to vendor export file
+VENDOR = 'amplitude'  # one of: amplitude, heap, ga4, posthog, mparticle, june, mixpanel
+VENDOR_OPTIONS = {}  # optional vendor-specific config (passed as dict)
+CREDENTIALS = {
+    "project_id": None,  # REQUIRED - your Mixpanel project ID
+    "service_account_username": "",  # REQUIRED - service account username
+    "service_account_password": "",  # REQUIRED - service account password
+    "token": "",  # REQUIRED - project token (for imports)
+}
+# ----- Configuration
+
+mputils = MixpanelUtils(
+    service_account_username=CREDENTIALS['service_account_username'],
+    service_account_password=CREDENTIALS['service_account_password'],
+    project_id=CREDENTIALS['project_id'],
+    token=CREDENTIALS['token'],
+)
+
+
+async def main():
+    print(f"Importing {VENDOR} data from {DATA_FILE}...")
+    result = await mputils.stream.import_events(DATA_FILE, {
+        'vendor': VENDOR,
+        'vendor_opts': VENDOR_OPTIONS,
+        'fix_data': True,
+    })
+
+    status = "PASS" if result.get('failed', 0) == 0 else "FAIL"
+    print(f"\n[{status}] {VENDOR.title()} vendor migration")
+    print(f"  total: {result.get('total', 0):,}  success: {result.get('success', 0):,}  failed: {result.get('failed', 0):,}")
+    if result.get('duration_human'):
+        print(f"  duration: {result['duration_human']}  requests: {result.get('requests', 0):,}")
+    if result.get('errors'):
+        for msg, count in result['errors'].items():
+            print(f"  error: {msg} (x{count})")
+
+
+asyncio.run(main())

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author='Jared McFarland',
     author_email='jared@mixpanel.com',
     url='https://github.com/mixpanel/mixpanel-utils',
-    python_requires='>=3.10',
+    python_requires='>=3',
     extras_require={
         'streaming': [
             'httpx>=0.27',

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,41 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
     name='mixpanel-utils',
-    packages=['mixpanel_utils'],
-    package_dir={'':'src'},
-    version='3.0.0',
+    packages=find_packages(where='src'),
+    package_dir={'': 'src'},
+    version='3.1.0',
     description='Utilities-only module for exporting and importing data into Mixpanel. NOT for server-side app tracking.',
     long_description='A utilities-only module for exporting and importing data into Mixpanel via their APIs. This is NOT for server-side app tracking. Service Account authentication required.',
     author='Jared McFarland',
     author_email='jared@mixpanel.com',
     url='https://github.com/mixpanel/mixpanel-utils',
-    python_requires='>=3'
+    python_requires='>=3.10',
+    extras_require={
+        'streaming': [
+            'httpx>=0.27',
+            'click>=8.0',
+            'pyarrow>=14.0',
+            'mmh3>=4.0',
+            'python-dateutil>=2.8',
+            'aiofiles>=23.0',
+        ],
+        'streaming-gcs': ['gcsfs>=2024.1'],
+        'streaming-s3': ['aiobotocore>=2.9'],
+        'streaming-all': [
+            'httpx>=0.27',
+            'click>=8.0',
+            'pyarrow>=14.0',
+            'mmh3>=4.0',
+            'python-dateutil>=2.8',
+            'aiofiles>=23.0',
+            'gcsfs>=2024.1',
+            'aiobotocore>=2.9',
+        ],
+    },
+    entry_points={
+        'console_scripts': [
+            'mixpanel-utils=mixpanel_utils.streaming.cli:main',
+        ],
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
             'aiofiles>=23.0',
         ],
         'streaming-gcs': ['gcsfs>=2024.1'],
-        'streaming-s3': ['aiobotocore>=2.9'],
+        'streaming-s3': ['boto3>=1.26'],
         'streaming-all': [
             'httpx>=0.27',
             'click>=8.0',
@@ -30,7 +30,7 @@ setup(
             'python-dateutil>=2.8',
             'aiofiles>=23.0',
             'gcsfs>=2024.1',
-            'aiobotocore>=2.9',
+            'boto3>=1.26',
         ],
     },
     entry_points={

--- a/src/mixpanel_utils/__init__.py
+++ b/src/mixpanel_utils/__init__.py
@@ -146,6 +146,17 @@ class MixpanelUtils(object):
         else:
             MixpanelUtils.LOGGER.setLevel(logging.WARNING)
 
+    @property
+    def stream(self):
+        """Async streaming interface for high-throughput import/export.
+
+        Requires streaming extras: pip install mixpanel-utils[streaming]
+        """
+        if not hasattr(self, '_stream'):
+            from .streaming import StreamInterface
+            self._stream = StreamInterface(self)
+        return self._stream
+
     @staticmethod
     def export_data(
             data, output_file, append_mode=False, format="json", compress=False

--- a/src/mixpanel_utils/streaming/__init__.py
+++ b/src/mixpanel_utils/streaming/__init__.py
@@ -11,15 +11,16 @@ from __future__ import annotations
 from .core.job import Job
 from .core.pipeline import core_pipeline
 from .io.parsers import resolve_input, _iter_list
+from .types import Creds, Options, ImportResults
 
 __version__ = "1.0.0"
 
 
 async def mp_import(
-    creds: dict | None = None,
+    creds: Creds | dict | None = None,
     data=None,
-    options: dict | None = None,
-) -> dict:
+    options: Options | dict | None = None,
+) -> ImportResults:
     """Stream events, users, and groups to Mixpanel.
 
     Args:
@@ -103,7 +104,7 @@ class MpStream:
         self._buffer: list[dict] = []
 
     @classmethod
-    async def create(cls, creds: dict, options: dict | None = None) -> "MpStream":
+    async def create(cls, creds: Creds | dict, options: Options | dict | None = None) -> "MpStream":
         from .io.http_client import MixpanelHttpClient
         options = options or {}
         job = Job(creds, options)
@@ -114,7 +115,7 @@ class MpStream:
     async def push(self, record: dict) -> None:
         self._buffer.append(record)
 
-    async def flush(self) -> dict:
+    async def flush(self) -> ImportResults:
         try:
             source = _iter_list(self._buffer)
             result = await core_pipeline(source, self._job, self._http_client)
@@ -163,7 +164,7 @@ class StreamInterface:
 
     # ── Import Methods ───────────────────────────────────────────────
 
-    async def import_events(self, data, options: dict | None = None) -> dict:
+    async def import_events(self, data, options: Options | dict | None = None) -> ImportResults:
         """Import events to Mixpanel.
 
         Args:
@@ -173,19 +174,19 @@ class StreamInterface:
         opts = self._merge_opts(options, record_type="event")
         return await mp_import(self._build_creds(), data, opts)
 
-    async def import_people(self, data, options: dict | None = None) -> dict:
+    async def import_people(self, data, options: Options | dict | None = None) -> ImportResults:
         """Import user profiles to Mixpanel."""
         opts = self._merge_opts(options, record_type="user")
         return await mp_import(self._build_creds(), data, opts)
 
-    async def import_groups(self, data, options: dict | None = None) -> dict:
+    async def import_groups(self, data, options: Options | dict | None = None) -> ImportResults:
         """Import group profiles to Mixpanel."""
         opts = self._merge_opts(options, record_type="group")
         return await mp_import(self._build_creds(), data, opts)
 
     # ── Export Methods ───────────────────────────────────────────────
 
-    async def export_events(self, filename: str | None = None, options: dict | None = None) -> dict:
+    async def export_events(self, filename: str | None = None, options: Options | dict | None = None) -> ImportResults:
         """Export events from Mixpanel.
 
         Args:
@@ -195,12 +196,12 @@ class StreamInterface:
         opts = self._merge_opts(options, record_type="export")
         return await mp_import(self._build_creds(), filename, opts)
 
-    async def export_people(self, folder: str | None = None, options: dict | None = None) -> dict:
+    async def export_people(self, folder: str | None = None, options: Options | dict | None = None) -> ImportResults:
         """Export user profiles from Mixpanel."""
         opts = self._merge_opts(options, record_type="profile-export")
         return await mp_import(self._build_creds(), folder, opts)
 
-    async def export_groups(self, folder: str | None = None, options: dict | None = None) -> dict:
+    async def export_groups(self, folder: str | None = None, options: Options | dict | None = None) -> ImportResults:
         """Export group profiles from Mixpanel."""
         creds = self._build_creds()
         opts = self._merge_opts(options, record_type="group-export")
@@ -210,7 +211,7 @@ class StreamInterface:
 
     # ── Export + Import (Round-Trip) Methods ──────────────────────────
 
-    async def export_import_events(self, options: dict | None = None) -> dict:
+    async def export_import_events(self, options: Options | dict | None = None) -> ImportResults:
         """Export events from this project and re-import them.
 
         Use 'second_token' in options to import into a different project.
@@ -218,12 +219,12 @@ class StreamInterface:
         opts = self._merge_opts(options, record_type="export-import-event")
         return await mp_import(self._build_creds(), None, opts)
 
-    async def export_import_people(self, options: dict | None = None) -> dict:
+    async def export_import_people(self, options: Options | dict | None = None) -> ImportResults:
         """Export user profiles and re-import them."""
         opts = self._merge_opts(options, record_type="export-import-profile")
         return await mp_import(self._build_creds(), None, opts)
 
-    async def export_import_groups(self, options: dict | None = None) -> dict:
+    async def export_import_groups(self, options: Options | dict | None = None) -> ImportResults:
         """Export group profiles and re-import them."""
         creds = self._build_creds()
         opts = self._merge_opts(options, record_type="export-import-group")

--- a/src/mixpanel_utils/streaming/__init__.py
+++ b/src/mixpanel_utils/streaming/__init__.py
@@ -7,6 +7,8 @@ Public API:
     StreamInterface — async interface attached to MixpanelUtils instances
 """
 
+from __future__ import annotations
+
 from .core.job import Job
 from .core.pipeline import core_pipeline
 from .io.parsers import resolve_input

--- a/src/mixpanel_utils/streaming/__init__.py
+++ b/src/mixpanel_utils/streaming/__init__.py
@@ -1,0 +1,255 @@
+"""Streaming pipeline for high-throughput Mixpanel data import/export.
+
+Public API:
+    mp_import(creds, data, options) — main async import function
+    MpStream — push-based streaming interface
+    validate_token(token) — validate a Mixpanel project token
+    StreamInterface — async interface attached to MixpanelUtils instances
+"""
+
+from .core.job import Job
+from .core.pipeline import core_pipeline
+from .io.parsers import resolve_input
+from .io.http_client import MixpanelHttpClient
+
+__version__ = "1.0.0"
+
+
+async def mp_import(
+    creds: dict | None = None,
+    data=None,
+    options: dict | None = None,
+) -> dict:
+    """Stream events, users, and groups to Mixpanel.
+
+    Args:
+        creds: Mixpanel credentials (token, acct/pass/project, or secret).
+        data: File path, list of dicts, async iterator, or cloud URL (gs://, s3://).
+        options: Import configuration options.
+
+    Returns:
+        ImportResults dict with success/failure counts and statistics.
+    """
+    options = options or {}
+    job = Job(creds, options)
+    await job.init()
+
+    # Handle export/delete record types
+    rt = job.record_type
+    if rt in ("export", "export-import-event"):
+        from .io.exporters import export_events
+        output_file = data or job.output_file_path
+        if rt == "export-import-event":
+            # Export then re-import: export to memory, then import
+            export_result = await export_events("", job)
+            if isinstance(export_result, list) and export_result:
+                import_opts = dict(options)
+                import_opts["record_type"] = "event"
+                import_opts["vendor"] = "mixpanel"
+                import_creds = dict(creds or {})
+                if job.second_token:
+                    import_creds["token"] = job.second_token
+                return await mp_import(import_creds, export_result, import_opts)
+            return job.summary()
+        else:
+            await export_events(output_file if isinstance(output_file, str) else "", job)
+            return job.summary()
+
+    if rt in ("profile-export", "group-export"):
+        from .io.exporters import export_profiles
+        output_dir = data or "./mixpanel-exports"
+        await export_profiles(output_dir if isinstance(output_dir, str) else "", job)
+        return job.summary()
+
+    if rt in ("profile-delete", "group-delete"):
+        from .io.exporters import delete_profiles
+        return await delete_profiles(job)
+
+    if rt == "export-import-profile":
+        from .io.exporters import export_profiles
+        export_result = await export_profiles("", job)
+        if export_result:
+            import_opts = dict(options)
+            import_opts["record_type"] = "user"
+            import_creds = dict(creds or {})
+            if job.second_token:
+                import_creds["token"] = job.second_token
+            return await mp_import(import_creds, export_result, import_opts)
+        return job.summary()
+
+    http_client = MixpanelHttpClient()
+    try:
+        source = await resolve_input(data, job)
+        result = await core_pipeline(source, job, http_client)
+        return result
+    finally:
+        await http_client.close()
+
+
+async def validate_token(token: str) -> dict:
+    """Validate a Mixpanel project token and detect ID management version."""
+    import httpx
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            "https://api.mixpanel.com/track",
+            json=[{
+                "event": "$mp_web_page_view",
+                "properties": {"token": token, "distinct_id": "token_validation_test"}
+            }],
+        )
+        try:
+            data = resp.json()
+            valid = data.get("status") == 1 or resp.status_code == 200
+        except Exception:
+            valid = False
+
+        return {"token": token, "valid": valid}
+
+
+class MpStream:
+    """Push-based streaming interface for piping data into Mixpanel.
+
+    Example:
+        stream = await MpStream.create(creds, options)
+        for record in my_data:
+            await stream.push(record)
+        result = await stream.flush()
+    """
+
+    def __init__(self, job: Job, http_client: MixpanelHttpClient):
+        self._job = job
+        self._http_client = http_client
+        self._buffer: list[dict] = []
+
+    @classmethod
+    async def create(cls, creds: dict, options: dict | None = None) -> "MpStream":
+        options = options or {}
+        job = Job(creds, options)
+        await job.init()
+        http_client = MixpanelHttpClient()
+        return cls(job, http_client)
+
+    async def push(self, record: dict) -> None:
+        self._buffer.append(record)
+
+    async def flush(self) -> dict:
+        try:
+            source = _iter_list(self._buffer)
+            result = await core_pipeline(source, self._job, self._http_client)
+            return result
+        finally:
+            await self._http_client.close()
+
+
+async def _iter_list(data: list):
+    for item in data:
+        yield item
+
+
+class StreamInterface:
+    """Async streaming interface attached to a MixpanelUtils instance.
+
+    Provides import, export, and round-trip methods that inherit
+    credentials from the parent MixpanelUtils object.
+    """
+
+    def __init__(self, parent):
+        self._parent = parent
+
+    def _build_creds(self) -> dict:
+        """Build credentials dict from parent MixpanelUtils instance."""
+        creds = {
+            "acct": self._parent.service_account_username,
+            "pass": self._parent.service_account_password,
+            "project": self._parent.project_id,
+        }
+        if self._parent.token:
+            creds["token"] = self._parent.token
+        if getattr(self._parent, "data_group_id", None):
+            creds["data_group_id"] = self._parent.data_group_id
+        if getattr(self._parent, "group_key", None):
+            creds["group_key"] = self._parent.group_key
+        return creds
+
+    def _region(self) -> str:
+        """Get region string from parent, normalized to uppercase."""
+        return (getattr(self._parent, "residency", "US") or "US").upper()
+
+    def _merge_opts(self, options: dict | None, **defaults) -> dict:
+        """Merge user options with defaults and region."""
+        opts = {"region": self._region()}
+        opts.update(defaults)
+        if options:
+            opts.update(options)
+        return opts
+
+    # ── Import Methods ───────────────────────────────────────────────
+
+    async def import_events(self, data, options: dict | None = None) -> dict:
+        """Import events to Mixpanel.
+
+        Args:
+            data: File path, list of dicts, async iterator, or cloud URL.
+            options: Import options (fix_data, vendor, transforms, etc.)
+        """
+        opts = self._merge_opts(options, record_type="event")
+        return await mp_import(self._build_creds(), data, opts)
+
+    async def import_people(self, data, options: dict | None = None) -> dict:
+        """Import user profiles to Mixpanel."""
+        opts = self._merge_opts(options, record_type="user")
+        return await mp_import(self._build_creds(), data, opts)
+
+    async def import_groups(self, data, options: dict | None = None) -> dict:
+        """Import group profiles to Mixpanel."""
+        opts = self._merge_opts(options, record_type="group")
+        return await mp_import(self._build_creds(), data, opts)
+
+    # ── Export Methods ───────────────────────────────────────────────
+
+    async def export_events(self, filename: str | None = None, options: dict | None = None) -> dict:
+        """Export events from Mixpanel.
+
+        Args:
+            filename: Output file path. None to return records in memory.
+            options: Export options (start, end, where, limit, etc.)
+        """
+        opts = self._merge_opts(options, record_type="export")
+        return await mp_import(self._build_creds(), filename, opts)
+
+    async def export_people(self, folder: str | None = None, options: dict | None = None) -> dict:
+        """Export user profiles from Mixpanel."""
+        opts = self._merge_opts(options, record_type="profile-export")
+        return await mp_import(self._build_creds(), folder, opts)
+
+    async def export_groups(self, folder: str | None = None, options: dict | None = None) -> dict:
+        """Export group profiles from Mixpanel."""
+        creds = self._build_creds()
+        opts = self._merge_opts(options, record_type="group-export")
+        if getattr(self._parent, "data_group_id", None):
+            opts.setdefault("data_group_id", self._parent.data_group_id)
+        return await mp_import(creds, folder, opts)
+
+    # ── Export + Import (Round-Trip) Methods ──────────────────────────
+
+    async def export_import_events(self, options: dict | None = None) -> dict:
+        """Export events from this project and re-import them.
+
+        Use 'second_token' in options to import into a different project.
+        """
+        opts = self._merge_opts(options, record_type="export-import-event")
+        return await mp_import(self._build_creds(), None, opts)
+
+    async def export_import_people(self, options: dict | None = None) -> dict:
+        """Export user profiles and re-import them."""
+        opts = self._merge_opts(options, record_type="export-import-profile")
+        return await mp_import(self._build_creds(), None, opts)
+
+    async def export_import_groups(self, options: dict | None = None) -> dict:
+        """Export group profiles and re-import them."""
+        creds = self._build_creds()
+        opts = self._merge_opts(options, record_type="export-import-profile")
+        if getattr(self._parent, "data_group_id", None):
+            opts.setdefault("data_group_id", self._parent.data_group_id)
+        return await mp_import(creds, None, opts)

--- a/src/mixpanel_utils/streaming/__init__.py
+++ b/src/mixpanel_utils/streaming/__init__.py
@@ -3,7 +3,6 @@
 Public API:
     mp_import(creds, data, options) — main async import function
     MpStream — push-based streaming interface
-    validate_token(token) — validate a Mixpanel project token
     StreamInterface — async interface attached to MixpanelUtils instances
 """
 
@@ -88,27 +87,6 @@ async def mp_import(
         await http_client.close()
 
 
-async def validate_token(token: str) -> dict:
-    """Validate a Mixpanel project token and detect ID management version."""
-    import httpx
-
-    async with httpx.AsyncClient() as client:
-        resp = await client.post(
-            "https://api.mixpanel.com/track",
-            json=[{
-                "event": "$mp_web_page_view",
-                "properties": {"token": token, "distinct_id": "token_validation_test"}
-            }],
-        )
-        try:
-            data = resp.json()
-            valid = data.get("status") == 1 or resp.status_code == 200
-        except Exception:
-            valid = False
-
-        return {"token": token, "valid": valid}
-
-
 class MpStream:
     """Push-based streaming interface for piping data into Mixpanel.
 
@@ -142,6 +120,7 @@ class MpStream:
             result = await core_pipeline(source, self._job, self._http_client)
             return result
         finally:
+            self._buffer.clear()
             await self._http_client.close()
 
 
@@ -252,7 +231,7 @@ class StreamInterface:
     async def export_import_groups(self, options: dict | None = None) -> dict:
         """Export group profiles and re-import them."""
         creds = self._build_creds()
-        opts = self._merge_opts(options, record_type="export-import-profile")
+        opts = self._merge_opts(options, record_type="export-import-group")
         if getattr(self._parent, "data_group_id", None):
             opts.setdefault("data_group_id", self._parent.data_group_id)
         return await mp_import(creds, None, opts)

--- a/src/mixpanel_utils/streaming/__init__.py
+++ b/src/mixpanel_utils/streaming/__init__.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 from .core.job import Job
 from .core.pipeline import core_pipeline
 from .io.parsers import resolve_input
-from .io.http_client import MixpanelHttpClient
 
 __version__ = "1.0.0"
 
@@ -79,6 +78,7 @@ async def mp_import(
             return await mp_import(import_creds, export_result, import_opts)
         return job.summary()
 
+    from .io.http_client import MixpanelHttpClient
     http_client = MixpanelHttpClient()
     try:
         source = await resolve_input(data, job)
@@ -119,13 +119,14 @@ class MpStream:
         result = await stream.flush()
     """
 
-    def __init__(self, job: Job, http_client: MixpanelHttpClient):
+    def __init__(self, job: Job, http_client):
         self._job = job
         self._http_client = http_client
         self._buffer: list[dict] = []
 
     @classmethod
     async def create(cls, creds: dict, options: dict | None = None) -> "MpStream":
+        from .io.http_client import MixpanelHttpClient
         options = options or {}
         job = Job(creds, options)
         await job.init()

--- a/src/mixpanel_utils/streaming/__init__.py
+++ b/src/mixpanel_utils/streaming/__init__.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from .core.job import Job
 from .core.pipeline import core_pipeline
-from .io.parsers import resolve_input
+from .io.parsers import resolve_input, _iter_list
 
 __version__ = "1.0.0"
 
@@ -65,12 +65,12 @@ async def mp_import(
         from .io.exporters import delete_profiles
         return await delete_profiles(job)
 
-    if rt == "export-import-profile":
+    if rt in ("export-import-profile", "export-import-group"):
         from .io.exporters import export_profiles
         export_result = await export_profiles("", job)
         if export_result:
             import_opts = dict(options)
-            import_opts["record_type"] = "user"
+            import_opts["record_type"] = "group" if rt == "export-import-group" else "user"
             import_creds = dict(creds or {})
             if job.second_token:
                 import_creds["token"] = job.second_token
@@ -122,11 +122,6 @@ class MpStream:
         finally:
             self._buffer.clear()
             await self._http_client.close()
-
-
-async def _iter_list(data: list):
-    for item in data:
-        yield item
 
 
 class StreamInterface:

--- a/src/mixpanel_utils/streaming/__main__.py
+++ b/src/mixpanel_utils/streaming/__main__.py
@@ -1,0 +1,6 @@
+"""Allow running as: python -m mixpanel_utils.streaming"""
+
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/src/mixpanel_utils/streaming/cli.py
+++ b/src/mixpanel_utils/streaming/cli.py
@@ -2,13 +2,12 @@
 
 import asyncio
 import json
-import os
 import sys
 
 import click
 
 from . import mp_import
-from .utils import comma, bytes_human
+from .utils import comma
 
 
 @click.command(context_settings={"max_content_width": 120})

--- a/src/mixpanel_utils/streaming/cli.py
+++ b/src/mixpanel_utils/streaming/cli.py
@@ -238,7 +238,7 @@ def _save_log(result: dict):
     timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     filename = f"mixpanel-import-{timestamp}.json"
 
-    log_data = {k: v for k, v in result.items() if k != "dry_run" or v}
+    log_data = {k: v for k, v in result.items() if k != "dry_run" and v}
     with open(filename, "w") as f:
         json.dump(log_data, f, indent=2, default=str)
     click.echo(f"  Log saved: {filename}")

--- a/src/mixpanel_utils/streaming/cli.py
+++ b/src/mixpanel_utils/streaming/cli.py
@@ -134,7 +134,12 @@ def main(data, **kwargs):
     no_data_types = ("export", "profile-export", "profile-delete", "group-export",
                      "group-delete", "export-import-event", "export-import-profile")
     if not data and rt not in no_data_types:
-        click.echo("Error: DATA argument is required (file path, directory, or cloud URL)", err=True)
+        click.echo("Usage: mixpanel-utils DATA --type TYPE --token TOKEN [options]", err=True)
+        click.echo("", err=True)
+        click.echo("  DATA is a file path, directory, glob, or cloud URL (gs://, s3://).", err=True)
+        click.echo("  For exports, DATA is optional.", err=True)
+        click.echo("", err=True)
+        click.echo("Run 'mixpanel-utils --help' for all options.", err=True)
         sys.exit(1)
 
     # Set up verbose progress display

--- a/src/mixpanel_utils/streaming/cli.py
+++ b/src/mixpanel_utils/streaming/cli.py
@@ -1,0 +1,243 @@
+"""CLI interface for mixpanel-utils streaming pipeline."""
+
+import asyncio
+import json
+import os
+import sys
+
+import click
+
+from . import mp_import
+from .utils import comma, bytes_human
+
+
+@click.command(context_settings={"max_content_width": 120})
+@click.argument("data", required=False)
+# ── Auth ─────────────────────────────────────────────────────────────
+@click.option("--project", type=int, help="Mixpanel project ID", envvar="MP_PROJECT")
+@click.option("--acct", help="Service account username", envvar="MP_ACCT")
+@click.option("--pass", "pass_", help="Service account password", envvar="MP_PASS")
+@click.option("--secret", help="Project API secret", envvar="MP_SECRET")
+@click.option("--token", help="Project token", envvar="MP_TOKEN")
+@click.option("--bearer", help="Bearer token for exports")
+@click.option("--group", "group_key", help="Group analytics group key")
+@click.option("--second-token", help="Second project token (export-import)")
+# ── Core Config ──────────────────────────────────────────────────────
+@click.option(
+    "--type", "record_type", default="event",
+    type=click.Choice([
+        "event", "user", "group", "export",
+        "profile-export", "profile-delete",
+        "group-export", "group-delete",
+        "export-import-event", "export-import-profile",
+    ]),
+    help="Record type to import/export",
+)
+@click.option(
+    "--region", default="US",
+    type=click.Choice(["US", "EU", "IN"]),
+    help="Data residency region",
+)
+@click.option(
+    "--format", "stream_format", default="",
+    type=click.Choice(["", "json", "jsonl", "csv", "parquet"], case_sensitive=False),
+    help="Data format (auto-detected from extension if omitted)",
+)
+@click.option(
+    "--vendor", default="",
+    type=click.Choice(["", "amplitude", "heap", "ga4", "posthog", "mparticle", "june", "mixpanel"]),
+    help="Apply vendor-specific transform",
+)
+@click.option("--vendor-opts", default="{}", help="JSON options for vendor transform")
+# ── Performance ──────────────────────────────────────────────────────
+@click.option("--workers", default=10, type=int, help="Concurrent HTTP connections")
+@click.option("--batch", "records_per_batch", default=2000, type=int, help="Records per batch")
+@click.option("--retries", "max_retries", default=10, type=int, help="Max retry attempts")
+@click.option("--compress/--no-compress", default=True, help="Gzip compress event requests")
+# ── Transforms ───────────────────────────────────────────────────────
+@click.option("--fix", "fix_data", is_flag=True, help="Apply automatic data fixes")
+@click.option("--fix-time", is_flag=True, help="Normalize timestamps to UNIX epoch")
+@click.option("--dedupe", is_flag=True, help="Remove duplicate records")
+@click.option("--remove-nulls", is_flag=True, help="Remove null/empty values")
+@click.option("--flatten", is_flag=True, help="Flatten nested properties")
+@click.option("--fix-json", is_flag=True, help="Parse string values that look like JSON")
+@click.option("--add-token", is_flag=True, help="Add token to each record")
+@click.option("--offset", "time_offset", default=0, type=int, help="UTC hours offset for timestamps")
+@click.option("--tags", default="{}", help="JSON tags to add to all records")
+@click.option("--aliases", default="{}", help="JSON key renames for properties")
+@click.option("--scrub-props", default="[]", help="JSON array of properties to remove")
+@click.option("--directive", default="$set", help="Profile operation ($set, $set_once, etc.)")
+@click.option("--v2-compat", is_flag=True, help="Set distinct_id from $user_id/$device_id")
+# ── Write to File ─────────────────────────────────────────────────────
+@click.option("--write-to-file", is_flag=True, help="Write transformed data to file instead of Mixpanel")
+@click.option("--output-file", "output_file_path", default="./mixpanel-transform.json", help="Output file path for write-to-file mode")
+@click.option("--dimension-maps", default="[]", help="JSON array of {filePath, keyOne, keyTwo, label} for lookup maps")
+# ── Filtering ────────────────────────────────────────────────────────
+@click.option("--epoch-start", default=0, type=int, help="Skip records before UNIX timestamp")
+@click.option("--epoch-end", default=9991427224, type=int, help="Skip records after UNIX timestamp")
+@click.option("--event-whitelist", default="[]", help="JSON array of allowed event names")
+@click.option("--event-blacklist", default="[]", help="JSON array of blocked event names")
+@click.option("--prop-key-whitelist", default="[]", help="JSON array of required property keys")
+@click.option("--prop-key-blacklist", default="[]", help="JSON array of blocked property keys")
+@click.option("--prop-val-whitelist", default="[]", help="JSON array of required property values")
+@click.option("--prop-val-blacklist", default="[]", help="JSON array of blocked property values")
+# ── Export ────────────────────────────────────────────────────────────
+@click.option("--start", help="Export start date (YYYY-MM-DD)")
+@click.option("--end", help="Export end date (YYYY-MM-DD)")
+@click.option("--where", "where_clause", help="WHERE clause for export filtering")
+@click.option("--limit", type=int, help="Maximum records to export")
+# ── Debug ────────────────────────────────────────────────────────────
+@click.option("--verbose/--quiet", default=True, help="Show progress output")
+@click.option("--dry-run", is_flag=True, help="Transform without sending to Mixpanel")
+@click.option("--strict/--no-strict", default=True, help="Validate data strictly")
+@click.option("--logs", is_flag=True, help="Save import log to file")
+# ── Cloud Storage ────────────────────────────────────────────────────
+@click.option("--s3-key", envvar="S3_KEY", help="AWS S3 access key")
+@click.option("--s3-secret", envvar="S3_SECRET", help="AWS S3 secret key")
+@click.option("--s3-region", envvar="S3_REGION", help="AWS S3 region")
+def main(data, **kwargs):
+    """Stream data into Mixpanel's ingestion APIs.
+
+    DATA is a file path, directory, glob pattern, or cloud URL (gs://, s3://).
+    """
+    # Build creds dict
+    cred_keys = ["project", "acct", "pass_", "secret", "token", "bearer",
+                 "group_key", "second_token",
+                 "s3_key", "s3_secret", "s3_region"]
+    creds = {}
+    for k in cred_keys:
+        val = kwargs.pop(k, None)
+        if val:
+            cred_key = "pass" if k == "pass_" else k
+            creds[cred_key] = val
+
+    # Map CLI names to options dict
+    opts = {}
+    for k, v in kwargs.items():
+        if v is not None and v != "" and v != []:
+            opts[k] = v
+
+    # Parse JSON string options
+    json_opts = ["tags", "aliases", "vendor_opts", "scrub_props",
+                 "event_whitelist", "event_blacklist",
+                 "prop_key_whitelist", "prop_key_blacklist",
+                 "prop_val_whitelist", "prop_val_blacklist",
+                 "dimension_maps"]
+    for key in json_opts:
+        if key in opts and isinstance(opts[key], str):
+            try:
+                opts[key] = json.loads(opts[key])
+            except json.JSONDecodeError:
+                pass
+
+    rt = opts.get("record_type", "")
+    no_data_types = ("export", "profile-export", "profile-delete", "group-export",
+                     "group-delete", "export-import-event", "export-import-profile")
+    if not data and rt not in no_data_types:
+        click.echo("Error: DATA argument is required (file path, directory, or cloud URL)", err=True)
+        sys.exit(1)
+
+    # Set up verbose progress display
+    verbose = opts.get("verbose", True)
+    if verbose and not opts.get("dry_run"):
+        _print_config_summary(data, rt, opts, creds)
+
+    # Run the import
+    try:
+        result = asyncio.run(mp_import(creds or None, data, opts))
+        _print_summary(result)
+
+        if opts.get("logs"):
+            _save_log(result)
+
+    except Exception as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+
+def _print_config_summary(data, record_type, opts, creds):
+    """Print a config summary box at the start of an import."""
+    click.echo("")
+    click.echo("=" * 60)
+    click.echo("  MIXPANEL STREAMING IMPORT")
+    click.echo("=" * 60)
+    click.echo(f"  Record Type:  {record_type or 'event'}")
+    click.echo(f"  Region:       {opts.get('region', 'US')}")
+    click.echo(f"  Data:         {data or '(none)'}")
+    if opts.get("vendor"):
+        click.echo(f"  Vendor:       {opts['vendor']}")
+    click.echo(f"  Workers:      {opts.get('workers', 10)}")
+    click.echo(f"  Batch Size:   {opts.get('records_per_batch', 2000)}")
+
+    features = []
+    if opts.get("fix_data"):
+        features.append("fix_data")
+    if opts.get("dedupe"):
+        features.append("dedupe")
+    if opts.get("compress", True):
+        features.append("gzip")
+    if opts.get("write_to_file"):
+        features.append(f"write_to_file({opts.get('output_file_path', 'mixpanel-transform.json')})")
+    if features:
+        click.echo(f"  Features:     {', '.join(features)}")
+
+    auth_type = "token" if creds.get("token") else "service_account" if creds.get("acct") else "secret" if creds.get("secret") else "none"
+    click.echo(f"  Auth:         {auth_type}")
+    click.echo("=" * 60)
+    click.echo("")
+
+
+def _print_summary(result: dict):
+    """Print import results summary."""
+    click.echo("")
+    click.echo("=" * 60)
+    click.echo("  IMPORT COMPLETE")
+    click.echo("=" * 60)
+    click.echo(f"  Record Type:  {result.get('record_type', 'unknown')}")
+    click.echo(f"  Duration:     {result.get('duration_human', 'N/A')}")
+    click.echo(f"  Total:        {comma(result.get('total', 0))}")
+    click.echo(f"  Success:      {comma(result.get('success', 0))}")
+    click.echo(f"  Failed:       {comma(result.get('failed', 0))}")
+
+    if result.get("empty"):
+        click.echo(f"  Empty:        {comma(result['empty'])}")
+    if result.get("duplicates"):
+        click.echo(f"  Duplicates:   {comma(result['duplicates'])}")
+    if result.get("out_of_bounds"):
+        click.echo(f"  Out of Bounds:{comma(result['out_of_bounds'])}")
+
+    click.echo(f"  Bytes:        {result.get('bytes_human', '0 B')}")
+    click.echo(f"  Requests:     {comma(result.get('requests', 0))}")
+    click.echo(f"  Retries:      {comma(result.get('retries', 0))}")
+
+    if result.get("eps"):
+        click.echo(f"  Events/sec:   {comma(result['eps'])}")
+    if result.get("rps"):
+        click.echo(f"  Requests/sec: {result['rps']:.2f}")
+    if result.get("mbps"):
+        click.echo(f"  MB/sec:       {result['mbps']:.3f}")
+
+    if result.get("errors"):
+        click.echo("")
+        click.echo("  Errors:")
+        for msg, count in result["errors"].items():
+            click.echo(f"    {msg}: {count}")
+
+    click.echo("=" * 60)
+    click.echo("")
+
+
+def _save_log(result: dict):
+    """Save import results to a JSON log file."""
+    from datetime import datetime
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    filename = f"mixpanel-import-{timestamp}.json"
+
+    log_data = {k: v for k, v in result.items() if k != "dry_run" or v}
+    with open(filename, "w") as f:
+        json.dump(log_data, f, indent=2, default=str)
+    click.echo(f"  Log saved: {filename}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mixpanel_utils/streaming/cli.py
+++ b/src/mixpanel_utils/streaming/cli.py
@@ -55,7 +55,7 @@ from .utils import comma, bytes_human
 @click.option("--retries", "max_retries", default=10, type=int, help="Max retry attempts")
 @click.option("--compress/--no-compress", default=True, help="Gzip compress event requests")
 # ── Transforms ───────────────────────────────────────────────────────
-@click.option("--fix", "fix_data", is_flag=True, help="Apply automatic data fixes")
+@click.option("--fix/--no-fix", "fix_data", default=True, help="Apply automatic data fixes (default: on)")
 @click.option("--fix-time", is_flag=True, help="Normalize timestamps to UNIX epoch")
 @click.option("--dedupe", is_flag=True, help="Remove duplicate records")
 @click.option("--remove-nulls", is_flag=True, help="Remove null/empty values")

--- a/src/mixpanel_utils/streaming/constants.py
+++ b/src/mixpanel_utils/streaming/constants.py
@@ -1,0 +1,116 @@
+"""Shared constants for the streaming pipeline."""
+
+# Mixpanel API base URLs by region
+BASE_URLS = {
+    "US": "https://api.mixpanel.com",
+    "EU": "https://api-eu.mixpanel.com",
+    "IN": "https://api-in.mixpanel.com",
+}
+
+# Export API base URLs by region
+EXPORT_BASE_URLS = {
+    "US": "https://data.mixpanel.com",
+    "EU": "https://data-eu.mixpanel.com",
+    "IN": "https://data-in.mixpanel.com",
+}
+
+# Profile export/engage base URLs
+ENGAGE_BASE_URLS = {
+    "US": "https://mixpanel.com",
+    "EU": "https://eu.mixpanel.com",
+    "IN": "https://in.mixpanel.com",
+}
+
+# API paths by record type
+API_PATHS = {
+    "event": "/import",
+    "user": "/engage",
+    "group": "/groups",
+    "export": "/api/2.0/export",
+    "profile-export": "/api/2.0/engage",
+    "profile-delete": "/api/2.0/engage",
+    "group-export": "/api/2.0/engage",
+    "group-delete": "/api/2.0/engage",
+}
+
+# HTTP methods by record type
+HTTP_METHODS = {
+    "event": "POST",
+    "user": "POST",
+    "group": "POST",
+    "export": "GET",
+    "profile-export": "POST",
+    "profile-delete": "POST",
+    "group-export": "POST",
+    "group-delete": "POST",
+}
+
+# Record types that use the export base URL
+EXPORT_RECORD_TYPES = {"export", "export-import-event"}
+
+# Record types that use the engage base URL
+ENGAGE_RECORD_TYPES = {
+    "profile-export", "profile-delete",
+    "group-export", "group-delete",
+    "export-import-profile", "export-import-group",
+}
+
+# Record types that support gzip compression on requests
+GZIP_RECORD_TYPES = {"event", "export-import-event"}
+
+# Status codes that trigger retry
+RETRY_STATUS_CODES = {429, 500, 501, 502, 503, 504, 508, 524}
+
+# Batch limits
+MAX_RECORDS_PER_BATCH = 2000
+MAX_BYTES_PER_BATCH = int(9.8 * 1024 * 1024)  # 9.8 MB
+DEFAULT_WORKERS = 10
+DEFAULT_MAX_RETRIES = 10
+DEFAULT_COMPRESSION_LEVEL = 6
+
+# Mixpanel reserved/special profile properties (get $ prefix)
+SPECIAL_PROPS = [
+    "name", "first_name", "last_name", "email", "phone", "avatar", "created",
+    "insert_id", "city", "region", "lib_version", "os", "os_version",
+    "browser", "browser_version", "app_build_number", "app_version_string",
+    "device", "screen_height", "screen_width", "screen_dpi", "current_url",
+    "initial_referrer", "initial_referring_domain", "referrer",
+    "referring_domain", "search_engine", "manufacturer", "brand", "model",
+    "watch_model", "carrier", "radio", "wifi", "bluetooth_enabled",
+    "bluetooth_version", "has_nfc", "has_telephone", "google_play_services",
+    "duration", "country", "country_code",
+]
+
+# Properties that belong at root level (outside $set)
+OUTSIDE_PROPS = ["distinct_id", "group_id", "token", "group_key", "ip"]
+
+# Valid profile operations
+VALID_OPERATIONS = ["$set", "$set_once", "$add", "$union", "$append", "$remove", "$unset"]
+
+# Known bad user IDs that should be filtered
+BAD_USER_IDS = [
+    "-1", "0", "00000000-0000-0000-0000-000000000000", "<nil>", "[]",
+    "anon", "anonymous", "false", "lmy47d", "n/a", "na", "nil", "none",
+    "null", "true", "undefined", "unknown", "{}",
+]
+
+# Max string length for property values
+MAX_STR_LEN = 255
+
+# Time field aliases (checked in priority order)
+TIME_FIELD_ALIASES = ["timestamp", "event_time", "ts_utc", "ts"]
+
+# File extensions by format
+JSONL_EXTENSIONS = {".jsonl", ".ndjson"}
+JSON_EXTENSIONS = {".json"}
+CSV_EXTENSIONS = {".csv", ".tsv"}
+PARQUET_EXTENSIONS = {".parquet"}
+GZIP_EXTENSIONS = {".gz", ".gzip"}
+
+# Compression config
+GZIP_LEVEL = 6
+GZIP_CHUNK_SIZE = 16 * 1024  # 16 KB
+
+# Default epoch bounds
+DEFAULT_EPOCH_START = 0
+DEFAULT_EPOCH_END = 9991427224

--- a/src/mixpanel_utils/streaming/core/__init__.py
+++ b/src/mixpanel_utils/streaming/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core pipeline and job management."""

--- a/src/mixpanel_utils/streaming/core/job.py
+++ b/src/mixpanel_utils/streaming/core/job.py
@@ -5,10 +5,8 @@ from __future__ import annotations
 import base64
 import json
 import os
-import sys
-import time
 from datetime import datetime, timedelta
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 from ..constants import (
     BASE_URLS, EXPORT_BASE_URLS, ENGAGE_BASE_URLS,

--- a/src/mixpanel_utils/streaming/core/job.py
+++ b/src/mixpanel_utils/streaming/core/job.py
@@ -1,5 +1,7 @@
 """Central state management class for import/export jobs."""
 
+from __future__ import annotations
+
 import base64
 import json
 import os

--- a/src/mixpanel_utils/streaming/core/job.py
+++ b/src/mixpanel_utils/streaming/core/job.py
@@ -10,12 +10,12 @@ from typing import Any, Callable
 
 from ..constants import (
     BASE_URLS, EXPORT_BASE_URLS, ENGAGE_BASE_URLS,
-    EXPORT_RECORD_TYPES, ENGAGE_RECORD_TYPES, GZIP_RECORD_TYPES,
-    HTTP_METHODS, VALID_OPERATIONS, MAX_RECORDS_PER_BATCH,
+    EXPORT_RECORD_TYPES, ENGAGE_RECORD_TYPES,
+    HTTP_METHODS, MAX_RECORDS_PER_BATCH,
     MAX_BYTES_PER_BATCH, DEFAULT_WORKERS, DEFAULT_MAX_RETRIES,
     DEFAULT_COMPRESSION_LEVEL, DEFAULT_EPOCH_START, DEFAULT_EPOCH_END,
 )
-from ..utils import bytes_human, comma, Timer
+from ..utils import bytes_human, Timer
 
 
 def _parse_json_option(val, default=None):
@@ -216,7 +216,6 @@ class Job:
 
         # ── Output Options ───────────────────────────────────────────
         self.output_file_path: str = opts.get("output_file_path", "./mixpanel-transform.json")
-        self.where_dir: str | None = opts.get("where")
         self.progress_callback: Callable | None = opts.get("progress_callback")
         if self.verbose and not self.progress_callback and not self.dry_run and not self.write_to_file:
             self.progress_callback = _default_progress

--- a/src/mixpanel_utils/streaming/core/job.py
+++ b/src/mixpanel_utils/streaming/core/job.py
@@ -98,6 +98,9 @@ def _default_progress(job):
         f"{eps:,} eps | "
         f"{time_str}"
     )
+    if job.errors:
+        top_err = max(job.errors, key=job.errors.get)
+        line += f" | {top_err}"
     w = _get_term_width()
     print("\r" + line[:w].ljust(w), end="", flush=True)
 

--- a/src/mixpanel_utils/streaming/core/job.py
+++ b/src/mixpanel_utils/streaming/core/job.py
@@ -1,0 +1,602 @@
+"""Central state management class for import/export jobs."""
+
+import base64
+import json
+import os
+import sys
+import time
+from datetime import datetime, timedelta
+from typing import Any, Callable, Optional
+
+from ..constants import (
+    BASE_URLS, EXPORT_BASE_URLS, ENGAGE_BASE_URLS,
+    EXPORT_RECORD_TYPES, ENGAGE_RECORD_TYPES, GZIP_RECORD_TYPES,
+    HTTP_METHODS, VALID_OPERATIONS, MAX_RECORDS_PER_BATCH,
+    MAX_BYTES_PER_BATCH, DEFAULT_WORKERS, DEFAULT_MAX_RETRIES,
+    DEFAULT_COMPRESSION_LEVEL, DEFAULT_EPOCH_START, DEFAULT_EPOCH_END,
+)
+from ..utils import bytes_human, comma, Timer
+
+
+def _parse_json_option(val, default=None):
+    """Parse a value that might be a JSON string, or return as-is."""
+    if default is None:
+        default = []
+    if val is None:
+        return default
+    if isinstance(val, str):
+        try:
+            return json.loads(val)
+        except json.JSONDecodeError:
+            try:
+                return json.loads(val.replace("'", '"'))
+            except json.JSONDecodeError:
+                return default
+    return val
+
+
+async def _build_map_from_path(file_path: str, key_one: str, key_two: str) -> dict:
+    """Load a JSON/JSONL file and build a key→value lookup dict."""
+    import aiofiles
+    from pathlib import Path
+
+    records = []
+    p = Path(file_path)
+    if not p.exists():
+        return {}
+
+    async with aiofiles.open(file_path, "r") as f:
+        content = await f.read()
+
+    content = content.strip()
+    if not content:
+        return {}
+
+    # Try JSON array first, then JSONL
+    try:
+        data = json.loads(content)
+        if isinstance(data, list):
+            records = data
+        else:
+            records = [data]
+    except json.JSONDecodeError:
+        for line in content.split("\n"):
+            line = line.strip()
+            if line:
+                try:
+                    records.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+
+    return {r[key_one]: r[key_two] for r in records if key_one in r and key_two in r}
+
+
+def _default_progress(job):
+    """Overwrite current terminal line with live import stats."""
+    elapsed = job.timer.elapsed()
+    if elapsed <= 0:
+        return
+    job._progress_written = True
+    hrs, rem = divmod(int(elapsed), 3600)
+    mins, secs = divmod(rem, 60)
+    time_str = f"{hrs:02d}:{mins:02d}:{secs:02d}"
+    eps = int(job.success / elapsed) if elapsed > 0 else 0
+    rps = job.requests / elapsed if elapsed > 0 else 0
+    mbps = (job.bytes_processed / 1_000_000) / elapsed if elapsed > 0 else 0
+    line = (
+        f"total: {job.records_processed:,} | "
+        f"success: {job.success:,} | "
+        f"failed: {job.failed:,} | "
+        f"empty: {job.empty:,} | "
+        f"req: {job.requests:,} | "
+        f"eps: {eps:,} | "
+        f"rps: {rps:.1f} | "
+        f"mbps: {mbps:.3f} | "
+        f"time: {time_str}"
+    )
+    try:
+        term_width = os.get_terminal_size(fallback=(80, 24)).columns
+    except (ValueError, OSError):
+        term_width = 80
+    print("\r" + line[:term_width].ljust(term_width), end="", flush=True)
+
+
+class Job:
+    """Central state holder for an import/export job.
+
+    Holds credentials, configuration, runtime counters, and transform functions.
+    """
+
+    def __init__(self, creds: dict | None = None, opts: dict | None = None):
+        opts = opts or {}
+        allow_empty = opts.get("dry_run") or opts.get("write_to_file") or opts.get("fix_data")
+        if not creds and not allow_empty:
+            raise ValueError("No credentials provided")
+        creds = creds or {}
+
+        # ── Credentials ──────────────────────────────────────────────
+        self.acct: str = creds.get("acct", "")
+        self.pass_: str = creds.get("pass", creds.get("pass_", ""))
+        self.project: str = str(creds["project"]) if creds.get("project") else ""
+        self.workspace: str = str(creds["workspace"]) if creds.get("workspace") else ""
+        self.org: str = str(creds["org"]) if creds.get("org") else ""
+        self.secret: str = creds.get("secret", "")
+        self.bearer: str = creds.get("bearer", "")
+        self.token: str = creds.get("token", "")
+        self.second_token: str = creds.get("second_token", creds.get("secondToken", ""))
+        self.group_key: str = creds.get("group_key", creds.get("groupKey", "")) or (str(opts.get("group_key", "")) if opts.get("group_key") else "")
+        self.data_group_id: str = creds.get("data_group_id", creds.get("dataGroupId", "")) or str(opts.get("data_group_id", opts.get("dataGroupId", "")))
+
+        # Cloud storage credentials
+        self.gcp_project_id: str = opts.get("gcp_project_id") or creds.get("gcp_project_id", creds.get("gcpProjectId", ""))
+        self.gcs_credentials: str = opts.get("gcs_credentials") or creds.get("gcs_credentials", creds.get("gcsCredentials", ""))
+        self.s3_key: str = opts.get("s3_key") or creds.get("s3_key", creds.get("s3Key", ""))
+        self.s3_secret: str = opts.get("s3_secret") or creds.get("s3_secret", creds.get("s3Secret", ""))
+        self.s3_region: str = opts.get("s3_region") or creds.get("s3_region", creds.get("s3Region", ""))
+
+        # ── Core Config ──────────────────────────────────────────────
+        self.record_type: str = opts.get("record_type", opts.get("recordType", "event"))
+        self.stream_format: str = opts.get("stream_format", opts.get("streamFormat", ""))
+        self.region: str = opts.get("region", "US").upper()
+        self.vendor: str = opts.get("vendor", "")
+        self.vendor_opts: dict = _parse_json_option(opts.get("vendor_opts", opts.get("vendorOpts")), {})
+
+        # ── Performance ──────────────────────────────────────────────
+        self.records_per_batch: int = opts.get("records_per_batch", opts.get("recordsPerBatch", MAX_RECORDS_PER_BATCH))
+        self.bytes_per_batch: int = opts.get("bytes_per_batch", opts.get("bytesPerBatch", MAX_BYTES_PER_BATCH))
+        self.max_retries: int = opts.get("max_retries", opts.get("maxRetries", DEFAULT_MAX_RETRIES))
+        self.workers: int = opts.get("workers", opts.get("concurrency", DEFAULT_WORKERS))
+        self.compression_level: int = opts.get("compression_level", opts.get("compressionLevel", DEFAULT_COMPRESSION_LEVEL))
+
+        # Clamp batch sizes
+        if self.records_per_batch > MAX_RECORDS_PER_BATCH:
+            self.records_per_batch = MAX_RECORDS_PER_BATCH
+
+        # ── Boolean Options ──────────────────────────────────────────
+        self.compress: bool = opts.get("compress", True)
+        self.strict: bool = opts.get("strict", True)
+        self.verbose: bool = opts.get("verbose", False)
+        self.fix_data: bool = opts.get("fix_data", opts.get("fixData", False))
+        self.fix_time: bool = opts.get("fix_time", opts.get("fixTime", False))
+        self.fix_json: bool = opts.get("fix_json", opts.get("fixJson", False))
+        self.remove_nulls: bool = opts.get("remove_nulls", opts.get("removeNulls", False))
+        self.flatten_data: bool = opts.get("flatten", opts.get("flattenData", False))
+        self.dedupe: bool = opts.get("dedupe", False)
+        self.dry_run: bool = opts.get("dry_run", opts.get("dryRun", False))
+        self.logs: bool = opts.get("logs", False)
+        self.abridged: bool = opts.get("abridged", False)
+        self.add_token: bool = opts.get("add_token", opts.get("addToken", False))
+        self.is_gzip: bool = opts.get("is_gzip", opts.get("isGzip", False))
+        self.write_to_file: bool = opts.get("write_to_file", opts.get("writeToFile", False))
+        self.v2_compat: bool = opts.get("v2_compat", False)
+        self.create_profiles: bool = opts.get("create_profiles", opts.get("createProfiles", False))
+
+        # ── Numeric Options ──────────────────────────────────────────
+        self.time_offset: int = opts.get("time_offset", opts.get("timeOffset", 0))
+        self.epoch_start: int = opts.get("epoch_start", opts.get("epochStart", DEFAULT_EPOCH_START))
+        self.epoch_end: int = opts.get("epoch_end", opts.get("epochEnd", DEFAULT_EPOCH_END))
+        self.max_records: int | None = opts.get("max_records", opts.get("maxRecords", None))
+
+        # ── String / JSON Options ────────────────────────────────────
+        self.directive: str = opts.get("directive", "$set")
+        self.tags: dict = _parse_json_option(opts.get("tags"), {})
+        self.aliases: dict = _parse_json_option(opts.get("aliases"), {})
+        self.scrub_props: list = _parse_json_option(opts.get("scrub_props", opts.get("scrubProps")), [])
+        self.drop_columns: list = _parse_json_option(opts.get("drop_columns", opts.get("dropColumns")), [])
+
+        # ── Whitelist/Blacklist ───────────────────────────────────────
+        self.event_whitelist: list = _parse_json_option(opts.get("event_whitelist", opts.get("eventWhitelist")), [])
+        self.event_blacklist: list = _parse_json_option(opts.get("event_blacklist", opts.get("eventBlacklist")), [])
+        self.prop_key_whitelist: list = _parse_json_option(opts.get("prop_key_whitelist", opts.get("propKeyWhitelist")), [])
+        self.prop_key_blacklist: list = _parse_json_option(opts.get("prop_key_blacklist", opts.get("propKeyBlacklist")), [])
+        self.prop_val_whitelist: list = _parse_json_option(opts.get("prop_val_whitelist", opts.get("propValWhitelist")), [])
+        self.prop_val_blacklist: list = _parse_json_option(opts.get("prop_val_blacklist", opts.get("propValBlacklist")), [])
+        self.combo_white_list: dict = _parse_json_option(opts.get("combo_white_list", opts.get("comboWhiteList")), {})
+        self.combo_black_list: dict = _parse_json_option(opts.get("combo_black_list", opts.get("comboBlackList")), {})
+
+        # ── Transform Functions ──────────────────────────────────────
+        self.transform_func: Callable | None = opts.get("transform_func", opts.get("transformFunc"))
+        self.vendor_transform: Callable | None = None
+        self.heavy_objects: dict = opts.get("heavy_objects", opts.get("heavyObjects", {}))
+        self.dimension_maps: list = _parse_json_option(opts.get("dimension_maps", opts.get("dimensionMaps")), [])
+        self.insert_id_tuple: list = opts.get("insert_id_tuple", opts.get("insertIdTuple", []))
+
+        # ── Export Options ───────────────────────────────────────────
+        today = datetime.utcnow()
+        start_default = (today - timedelta(days=30)).strftime("%Y-%m-%d")
+        end_default = today.strftime("%Y-%m-%d")
+        self.start: str = opts.get("start", start_default)
+        self.end: str = opts.get("end", end_default)
+        self.where_clause: str = opts.get("where", opts.get("whereClause", ""))
+        self.limit: int | None = opts.get("limit")
+        self.cohort_id: int | None = opts.get("cohort_id", opts.get("cohortId"))
+        self.params: dict = opts.get("params", {})
+
+        # ── Output Options ───────────────────────────────────────────
+        self.output_file_path: str = opts.get("output_file_path", "./mixpanel-transform.json")
+        self.where_dir: str | None = opts.get("where")
+        self.progress_callback: Callable | None = opts.get("progress_callback")
+        if self.verbose and not self.progress_callback and not self.dry_run and not self.write_to_file:
+            self.progress_callback = _default_progress
+
+        # ── Runtime State ────────────────────────────────────────────
+        self.start_time: str = datetime.utcnow().isoformat() + "Z"
+        self.end_time: str | None = None
+        self.hash_table: set = set()
+        self.dry_run_results: list = []
+
+        # Counters
+        self.records_processed: int = 0
+        self.success: int = 0
+        self.failed: int = 0
+        self.retries: int = 0
+        self.batches: int = 0
+        self.requests: int = 0
+        self.empty: int = 0
+        self.rate_limited: int = 0
+        self.server_errors: int = 0
+        self.client_errors: int = 0
+        self.bytes_processed: int = 0
+        self.out_of_bounds: int = 0
+        self.duplicates: int = 0
+        self.whitelist_skipped: int = 0
+        self.blacklist_skipped: int = 0
+        self.unparsable: int = 0
+        self.last_batch_length: int = 0
+
+        self.responses: list = []
+        self.errors: dict[str, int] = {}
+
+        # Timer
+        self.timer = Timer()
+        self.timer.start()
+
+        # ── Request Config ───────────────────────────────────────────
+        self.req_method: str = HTTP_METHODS.get(self.record_type, "POST")
+        self.content_type: str = "application/json"
+
+        # Validate record type
+        _validate_record_type(self.record_type)
+
+        # Resolve auth
+        self.auth: str = self._resolve_auth()
+
+        # Build active transforms list (done after all options are set)
+        self.active_transforms: list[Callable] = []
+        self._build_transforms()
+
+    # ── Properties ───────────────────────────────────────────────────
+
+    @property
+    def url(self) -> str:
+        """Get the Mixpanel API URL for current record type and region."""
+        region = self.region.upper()
+        rt = self.record_type.lower()
+
+        if rt in EXPORT_RECORD_TYPES:
+            base = EXPORT_BASE_URLS.get(region, EXPORT_BASE_URLS["US"])
+            return f"{base}/api/2.0/export"
+        elif rt in ENGAGE_RECORD_TYPES:
+            base = ENGAGE_BASE_URLS.get(region, ENGAGE_BASE_URLS["US"])
+            return f"{base}/api/2.0/engage"
+        else:
+            base = BASE_URLS.get(region, BASE_URLS["US"])
+            path_map = {
+                "event": "/import",
+                "user": "/engage",
+                "group": "/groups",
+            }
+            path = path_map.get(rt, "/import")
+            return f"{base}{path}"
+
+    # ── Auth ─────────────────────────────────────────────────────────
+
+    def _resolve_auth(self) -> str:
+        """Resolve authentication header value."""
+        is_import = self.record_type in ("event", "user", "group")
+
+        # Service account auth (preferred)
+        if self.acct and self.pass_ and self.project:
+            return "Basic " + base64.b64encode(f"{self.acct}:{self.pass_}".encode()).decode()
+
+        # Token auth for imports
+        if is_import and self.token:
+            return "Basic " + base64.b64encode(f"{self.token}:".encode()).decode()
+
+        # Validate export with service account needs project
+        export_types = {"export", "profile-export", "group-export", "profile-delete",
+                        "export-import-event", "export-import-profile"}
+        if self.record_type in export_types and self.acct and self.pass_ and not self.project:
+            raise ValueError("Export with service account auth requires project_id")
+
+        # API secret auth
+        if self.secret:
+            return "Basic " + base64.b64encode(f"{self.secret}:".encode()).decode()
+
+        # Fallback token for non-imports
+        if self.token and not is_import:
+            return "Basic " + base64.b64encode(f"{self.token}:".encode()).decode()
+
+        # Bearer token
+        if self.bearer:
+            return f"Bearer {self.bearer}"
+
+        # Allow empty auth for dry runs, profiles without token, etc.
+        if self.dry_run or self.write_to_file or self.record_type in ("user", "group"):
+            return ""
+
+        if "export" in self.record_type:
+            raise ValueError("Export operations require API secret or service account (acct + pass + project)")
+
+        raise ValueError("No valid authentication method found")
+
+    # ── Transforms ───────────────────────────────────────────────────
+
+    def _build_transforms(self):
+        """Pre-compute the list of active helper transforms."""
+        from ..transforms.builtin import (
+            ez_transforms, apply_aliases, add_tags, add_token,
+            remove_nulls, flatten_properties, utc_offset,
+            fix_time, fix_json, scrub_properties, drop_columns,
+            set_distinct_id_from_v2_props, add_insert,
+        )
+        from ..transforms.filters import whitelist_blacklist, epoch_filter
+        from ..transforms.dedup import dedupe_records
+
+        transforms = []
+
+        if self.aliases:
+            transforms.append(apply_aliases(self))
+        if self.fix_data or "export-import" in self.record_type:
+            transforms.append(ez_transforms(self))
+        if self.v2_compat and self.record_type == "event":
+            transforms.append(set_distinct_id_from_v2_props())
+        if self.remove_nulls:
+            transforms.append(remove_nulls())
+        if self.time_offset:
+            transforms.append(utc_offset(self.time_offset))
+        if self.tags:
+            transforms.append(add_tags(self))
+
+        # Check for whitelist/blacklist
+        wb_params = {
+            "event_whitelist": self.event_whitelist,
+            "event_blacklist": self.event_blacklist,
+            "prop_key_whitelist": self.prop_key_whitelist,
+            "prop_key_blacklist": self.prop_key_blacklist,
+            "prop_val_whitelist": self.prop_val_whitelist,
+            "prop_val_blacklist": self.prop_val_blacklist,
+            "combo_white_list": self.combo_white_list,
+            "combo_black_list": self.combo_black_list,
+        }
+        has_wb = any(
+            (isinstance(v, list) and len(v) > 0) or (isinstance(v, dict) and len(v) > 0)
+            for v in wb_params.values()
+        )
+        if has_wb:
+            transforms.append(whitelist_blacklist(self, wb_params))
+
+        if self.epoch_start or self.epoch_end != DEFAULT_EPOCH_END:
+            transforms.append(epoch_filter(self))
+        if self.scrub_props:
+            transforms.append(scrub_properties(self.scrub_props))
+        if self.drop_columns:
+            transforms.append(drop_columns(self.drop_columns))
+        if self.flatten_data:
+            transforms.append(flatten_properties())
+        if self.fix_json:
+            transforms.append(fix_json())
+        if self.insert_id_tuple and self.record_type == "event":
+            transforms.append(add_insert(self.insert_id_tuple))
+        if self.add_token:
+            transforms.append(add_token(self))
+        if self.fix_time and self.record_type == "event":
+            transforms.append(fix_time())
+
+        self.active_transforms = transforms
+
+        # Dedup transform (separate, used in pipeline directly)
+        if self.dedupe:
+            self.deduper = dedupe_records(self)
+        else:
+            self.deduper = None
+
+    async def insert_heavy_objects(self):
+        """Load dimension maps from files into heavy_objects dict."""
+        if self.heavy_objects or not self.dimension_maps:
+            return
+        for dim_map in self.dimension_maps:
+            file_path = dim_map.get("filePath") or dim_map.get("file_path")
+            key_one = dim_map.get("keyOne") or dim_map.get("key_one")
+            key_two = dim_map.get("keyTwo") or dim_map.get("key_two")
+            label = dim_map.get("label", f"map_{len(self.heavy_objects)}")
+
+            if not file_path or not key_one or not key_two:
+                continue
+
+            id_map = await _build_map_from_path(file_path, key_one, key_two)
+            self.heavy_objects[label] = id_map
+
+    async def init(self):
+        """Initialize vendor transforms and heavy objects."""
+        await self.insert_heavy_objects()
+        if self.vendor:
+            self._init_vendor_transform()
+
+    def _init_vendor_transform(self):
+        """Set up vendor-specific transform function."""
+        from ..transforms.dedup import dedupe_records
+
+        vendor = self.vendor.lower()
+        rt = self.record_type.lower()
+
+        if vendor == "amplitude":
+            from ..vendors.amplitude import amp_events_to_mp, amp_user_to_mp, amp_group_to_mp
+            if rt == "event":
+                self.vendor_transform = amp_events_to_mp(self.vendor_opts)
+            elif rt == "user":
+                self.dedupe = True
+                self.deduper = dedupe_records(self)
+                self.vendor_transform = amp_user_to_mp(self.vendor_opts)
+            elif rt == "group":
+                self.vendor_transform = amp_group_to_mp(self.vendor_opts)
+            else:
+                self.vendor_transform = amp_events_to_mp(self.vendor_opts)
+
+        elif vendor == "heap":
+            from ..vendors.heap import heap_events_to_mp, heap_user_to_mp, heap_group_to_mp
+            if rt == "event":
+                self.vendor_transform = heap_events_to_mp(self.vendor_opts)
+            elif rt == "user":
+                self.vendor_transform = heap_user_to_mp(self.vendor_opts)
+            elif rt == "group":
+                self.vendor_transform = heap_group_to_mp(self.vendor_opts)
+            else:
+                self.vendor_transform = heap_events_to_mp(self.vendor_opts)
+
+        elif vendor == "ga4":
+            from ..vendors.ga4 import ga_events_to_mp, ga_user_to_mp, ga_groups_to_mp
+            if rt == "event":
+                self.vendor_transform = ga_events_to_mp(self.vendor_opts)
+            elif rt == "user":
+                self.dedupe = True
+                self.deduper = dedupe_records(self)
+                self.vendor_transform = ga_user_to_mp(self.vendor_opts)
+            elif rt == "group":
+                self.vendor_transform = ga_groups_to_mp(self.vendor_opts)
+            else:
+                self.vendor_transform = ga_events_to_mp(self.vendor_opts)
+
+        elif vendor == "mparticle":
+            from ..vendors.mparticle import mparticle_events_to_mixpanel, mparticle_user_to_mixpanel, mparticle_group_to_mixpanel
+            if rt == "event":
+                self.vendor_transform = mparticle_events_to_mixpanel(self.vendor_opts)
+            elif rt == "user":
+                self.dedupe = True
+                self.deduper = dedupe_records(self)
+                self.vendor_transform = mparticle_user_to_mixpanel(self.vendor_opts)
+            elif rt == "group":
+                self.vendor_transform = mparticle_group_to_mixpanel(self.vendor_opts)
+            else:
+                self.vendor_transform = mparticle_events_to_mixpanel(self.vendor_opts)
+
+        elif vendor == "posthog":
+            from ..vendors.posthog import posthog_events_to_mp, posthog_person_to_mp_profile
+            if rt == "event":
+                self.vendor_transform = posthog_events_to_mp(self.vendor_opts, self.heavy_objects)
+            elif rt == "user":
+                self.dedupe = True
+                self.deduper = dedupe_records(self)
+                self.vendor_transform = posthog_person_to_mp_profile(self.vendor_opts)
+            elif rt == "group":
+                raise ValueError("PostHog does not support group transforms")
+            else:
+                self.vendor_transform = posthog_events_to_mp(self.vendor_opts, self.heavy_objects)
+
+        elif vendor == "june":
+            from ..vendors.june import june_events_to_mp, june_user_to_mp, june_group_to_mp
+            if rt == "event":
+                self.vendor_transform = june_events_to_mp(self.vendor_opts)
+            elif rt == "user":
+                self.dedupe = True
+                self.deduper = dedupe_records(self)
+                self.vendor_transform = june_user_to_mp(self.vendor_opts)
+            elif rt == "group":
+                self.vendor_transform = june_group_to_mp(self.vendor_opts)
+            else:
+                self.vendor_transform = june_events_to_mp(self.vendor_opts)
+
+        elif vendor == "mixpanel":
+            from ..vendors.mixpanel import mixpanel_events_to_mixpanel
+            self.vendor_transform = mixpanel_events_to_mixpanel(self.vendor_opts)
+
+    # ── Response Handling ────────────────────────────────────────────
+
+    def store(self, response: Any, success: bool = True, batch: list | None = None):
+        """Store API response and update error counts."""
+        if not self.abridged and response is not None:
+            self.responses.append(response)
+
+        if not success:
+            if response and isinstance(response, dict):
+                if "failed_records" in response and isinstance(response["failed_records"], list):
+                    for failure in response["failed_records"]:
+                        msg = failure.get("message", "unknown error")
+                        self.errors[msg] = self.errors.get(msg, 0) + 1
+                elif response.get("error"):
+                    msg = response["error"]
+                    self.errors[msg] = self.errors.get(msg, 0) + 1
+                elif response.get("message"):
+                    msg = response["message"]
+                    self.errors[msg] = self.errors.get(msg, 0) + 1
+                else:
+                    self.errors["unknown error"] = self.errors.get("unknown error", 0) + 1
+            elif isinstance(response, str):
+                self.errors[response] = self.errors.get(response, 0) + 1
+            else:
+                self.errors["unknown error"] = self.errors.get("unknown error", 0) + 1
+
+    # ── Summary ──────────────────────────────────────────────────────
+
+    def summary(self) -> dict:
+        """Generate final import/export results summary."""
+        self.timer.stop()
+        report = self.timer.report()
+        delta = report["delta"]
+        human = report["human"]
+
+        result = {
+            "record_type": self.record_type,
+            "total": self.records_processed,
+            "success": self.success,
+            "failed": self.failed,
+            "empty": self.empty,
+            "out_of_bounds": self.out_of_bounds,
+            "duplicates": self.duplicates,
+            "whitelist_skipped": self.whitelist_skipped,
+            "blacklist_skipped": self.blacklist_skipped,
+            "unparsable": self.unparsable,
+            "start_time": self.start_time,
+            "end_time": datetime.utcnow().isoformat() + "Z",
+            "duration": delta,
+            "duration_human": human,
+            "bytes": self.bytes_processed,
+            "bytes_human": bytes_human(self.bytes_processed),
+            "requests": self.requests,
+            "batches": self.batches,
+            "retries": self.retries,
+            "rate_limit": self.rate_limited,
+            "server_errors": self.server_errors,
+            "client_errors": self.client_errors,
+            "eps": 0,
+            "rps": 0.0,
+            "mbps": 0.0,
+            "errors": self.errors,
+            "responses": self.responses,
+            "dry_run": self.dry_run_results,
+            "vendor": self.vendor or "",
+            "vendor_opts": self.vendor_opts,
+        }
+
+        # Calculate rates
+        if result["total"] and delta and result["requests"] and result["bytes"]:
+            duration_s = delta / 1000
+            result["eps"] = int(result["total"] / duration_s)
+            result["rps"] = round(result["requests"] / duration_s, 3)
+            result["mbps"] = round((result["bytes"] / 1e6) / duration_s, 3)
+
+        return result
+
+
+def _validate_record_type(rt: str):
+    """Validate record type, rejecting plural forms."""
+    plural_map = {"events": "event", "users": "user", "groups": "group"}
+    if rt in plural_map:
+        raise ValueError(
+            f'Invalid record_type: "{rt}" (plural form not allowed). '
+            f'Use the singular form: "{plural_map[rt]}"'
+        )
+    valid_prefixes = ["event", "user", "group", "export",
+                      "profile-", "export-import-"]
+    if rt and not any(rt.startswith(p) or rt == p for p in valid_prefixes):
+        raise ValueError(f'Invalid record_type: "{rt}"')

--- a/src/mixpanel_utils/streaming/core/job.py
+++ b/src/mixpanel_utils/streaming/core/job.py
@@ -71,6 +71,13 @@ async def _build_map_from_path(file_path: str, key_one: str, key_two: str) -> di
     return {r[key_one]: r[key_two] for r in records if key_one in r and key_two in r}
 
 
+def _get_term_width() -> int:
+    try:
+        return os.get_terminal_size().columns
+    except (ValueError, OSError, AttributeError):
+        return 120
+
+
 def _default_progress(job):
     """Overwrite current terminal line with live import stats."""
     elapsed = job.timer.elapsed()
@@ -81,24 +88,16 @@ def _default_progress(job):
     mins, secs = divmod(rem, 60)
     time_str = f"{hrs:02d}:{mins:02d}:{secs:02d}"
     eps = int(job.success / elapsed) if elapsed > 0 else 0
-    rps = job.requests / elapsed if elapsed > 0 else 0
-    mbps = (job.bytes_processed / 1_000_000) / elapsed if elapsed > 0 else 0
     line = (
-        f"total: {job.records_processed:,} | "
-        f"success: {job.success:,} | "
-        f"failed: {job.failed:,} | "
-        f"empty: {job.empty:,} | "
-        f"req: {job.requests:,} | "
-        f"eps: {eps:,} | "
-        f"rps: {rps:.1f} | "
-        f"mbps: {mbps:.3f} | "
-        f"time: {time_str}"
+        f"  {job.records_processed:,} records | "
+        f"{job.success:,} ok | "
+        f"{job.failed:,} err | "
+        f"{job.requests:,} req | "
+        f"{eps:,} eps | "
+        f"{time_str}"
     )
-    try:
-        term_width = os.get_terminal_size(fallback=(80, 24)).columns
-    except (ValueError, OSError):
-        term_width = 80
-    print("\r" + line[:term_width].ljust(term_width), end="", flush=True)
+    w = _get_term_width()
+    print("\r" + line[:w].ljust(w), end="", flush=True)
 
 
 class Job:

--- a/src/mixpanel_utils/streaming/core/pipeline.py
+++ b/src/mixpanel_utils/streaming/core/pipeline.py
@@ -202,7 +202,7 @@ async def send_batches(batches: AsyncIterator[list[dict]], job, http_client):
             response, success = await http_client.send_batch(batch, job)
 
             # Update counters based on record type
-            if job.record_type in ("event", "scd", "export-import-event"):
+            if job.record_type in ("event", "export-import-event"):
                 job.success += response.get("num_records_imported", 0)
                 failed_records = response.get("failed_records", [])
                 job.failed += len(failed_records) if isinstance(failed_records, list) else 0

--- a/src/mixpanel_utils/streaming/core/pipeline.py
+++ b/src/mixpanel_utils/streaming/core/pipeline.py
@@ -1,0 +1,284 @@
+"""Async generator pipeline for streaming data through transforms to Mixpanel.
+
+Each stage is an async generator: async def stage(source, job) -> AsyncIterator
+Stages are chained together and consume records lazily with natural backpressure.
+"""
+
+import asyncio
+import json
+import logging
+from typing import AsyncIterator
+
+logger = logging.getLogger(__name__)
+
+
+def _is_not_empty(data) -> bool:
+    if data is None:
+        return False
+    if not isinstance(data, (dict, list)):
+        return False
+    if isinstance(data, list):
+        return len(data) > 0
+    return len(data) > 0
+
+
+# ── Pipeline Stages ──────────────────────────────────────────────────
+
+async def existence_filter(source: AsyncIterator[dict], job) -> AsyncIterator[dict]:
+    """Skip empty records and enforce max_records limit."""
+    async for chunk in source:
+        if job.max_records is not None and job.records_processed >= job.max_records:
+            return
+        if _is_not_empty(chunk):
+            job.records_processed += 1
+            yield chunk
+        else:
+            job.empty += 1
+
+
+async def vendor_transform(source: AsyncIterator[dict], job) -> AsyncIterator[dict]:
+    """Apply vendor-specific transform (Amplitude, Heap, GA4, etc.)."""
+    if not job.vendor_transform:
+        async for record in source:
+            yield record
+        return
+
+    async for record in source:
+        try:
+            result = job.vendor_transform(record)
+        except Exception as e:
+            logger.debug(f"Vendor transform error: {e}")
+            msg = f"vendor transform: {e}"
+            job.errors[msg] = job.errors.get(msg, 0) + 1
+            job.empty += 1
+            continue
+
+        if result is None:
+            job.empty += 1
+        elif isinstance(result, list):
+            yield result  # Will be flattened downstream
+        elif _is_not_empty(result):
+            yield result
+        else:
+            job.empty += 1
+
+
+async def flatten_stream(source: AsyncIterator, job) -> AsyncIterator[dict]:
+    """Explode arrays into individual records."""
+    async for item in source:
+        if isinstance(item, list):
+            for record in item:
+                if _is_not_empty(record):
+                    yield record
+        else:
+            yield item
+
+
+async def user_transform(source: AsyncIterator[dict], job) -> AsyncIterator[dict]:
+    """Apply custom user-provided transform function."""
+    if not job.transform_func:
+        async for record in source:
+            yield record
+        return
+
+    async for record in source:
+        try:
+            result = job.transform_func(record)
+        except Exception as e:
+            logger.debug(f"User transform error: {e}")
+            job.empty += 1
+            continue
+
+        if result is None:
+            job.empty += 1
+        elif isinstance(result, list):
+            yield result  # Will be flattened downstream
+        elif _is_not_empty(result):
+            yield result
+        else:
+            job.empty += 1
+
+
+async def dedupe_transform(source: AsyncIterator[dict], job) -> AsyncIterator[dict]:
+    """Deduplicate records by content hash."""
+    if not job.deduper:
+        async for record in source:
+            yield record
+        return
+
+    async for record in source:
+        result = job.deduper(record)
+        if _is_not_empty(result):
+            yield result
+
+
+async def post_transform_filter(source: AsyncIterator[dict], job) -> AsyncIterator[dict]:
+    """Post-transform existence check (does NOT increment records_processed)."""
+    async for chunk in source:
+        if _is_not_empty(chunk):
+            yield chunk
+        else:
+            job.empty += 1
+
+
+async def helper_transforms(source: AsyncIterator[dict], job) -> AsyncIterator[dict]:
+    """Apply all active helper transforms (aliases, tags, fixData, etc.)."""
+    transforms = job.active_transforms
+
+    if not transforms:
+        async for record in source:
+            yield record
+        return
+
+    async for record in source:
+        skip = False
+        for fn in transforms:
+            result = fn(record)
+            if result is None or (isinstance(result, dict) and len(result) == 0):
+                job.empty += 1
+                skip = True
+                break
+            record = result
+        if not skip:
+            yield record
+
+
+async def compute_sizes(source: AsyncIterator[dict], job) -> AsyncIterator[tuple[dict, int]]:
+    """Compute JSON byte size for each record."""
+    async for record in source:
+        size = len(json.dumps(record).encode("utf-8"))
+        job.bytes_processed += size
+        yield (record, size)
+
+
+async def smart_batcher(source: AsyncIterator[tuple[dict, int]], job) -> AsyncIterator[list[dict]]:
+    """Batch records by count AND size, whichever limit is hit first."""
+    buffer: list[dict] = []
+    current_size = 0
+    max_count = job.records_per_batch
+    max_bytes = int(job.bytes_per_batch * 0.985)  # Safety margin
+
+    async for record, size in source:
+        if buffer and (len(buffer) >= max_count or current_size + size > max_bytes):
+            job.batches += 1
+            job.last_batch_length = len(buffer)
+            yield buffer
+            buffer = []
+            current_size = 0
+        buffer.append(record)
+        current_size += size
+
+    if buffer:
+        job.batches += 1
+        job.last_batch_length = len(buffer)
+        yield buffer
+
+
+async def send_batches(batches: AsyncIterator[list[dict]], job, http_client):
+    """Send batches concurrently using asyncio.Semaphore for backpressure."""
+    semaphore = asyncio.Semaphore(job.workers)
+    tasks: set[asyncio.Task] = set()
+    errors: list[Exception] = []
+
+    async def _send_one(batch: list[dict]):
+        try:
+            await semaphore.acquire()
+            job.requests += 1
+
+            if job.dry_run:
+                job.dry_run_results.extend(batch)
+                job.success += len(batch)
+                return
+
+            if job.write_to_file:
+                import aiofiles
+                async with aiofiles.open(job.output_file_path, "a") as f:
+                    for record in batch:
+                        await f.write(json.dumps(record) + "\n")
+                job.success += len(batch)
+                return
+
+            response, success = await http_client.send_batch(batch, job)
+
+            # Update counters based on record type
+            if job.record_type in ("event", "scd", "export-import-event"):
+                job.success += response.get("num_records_imported", 0)
+                failed_records = response.get("failed_records", [])
+                job.failed += len(failed_records) if isinstance(failed_records, list) else 0
+            elif job.record_type in ("user", "group"):
+                if response.get("error") or not response.get("status", True):
+                    job.failed += len(batch)
+                else:
+                    num_good = response.get("num_good_events", 0)
+                    job.success += num_good if num_good else len(batch)
+
+            # Store response (preserve failed_records for error tracking)
+            abbreviated = {
+                "num_records_imported": response.get("num_records_imported", 0),
+                "num_failed": len(response.get("failed_records", [])) if isinstance(response.get("failed_records"), list) else 0,
+                "failed_records": response.get("failed_records"),
+                "error": response.get("error"),
+                "status": response.get("status", success),
+            }
+            job.store(abbreviated, success)
+
+        except Exception as e:
+            logger.error(f"Batch send error: {e}")
+            errors.append(e)
+            job.failed += len(batch)
+        finally:
+            semaphore.release()
+            if job.progress_callback:
+                try:
+                    job.progress_callback(job)
+                except Exception:
+                    pass
+
+    async for batch in batches:
+        task = asyncio.create_task(_send_one(batch))
+        tasks.add(task)
+        task.add_done_callback(tasks.discard)
+
+        # Check for errors
+        if errors:
+            logger.error(f"Stopping due to errors: {errors}")
+            break
+
+    # Wait for remaining tasks
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+# ── Pipeline Orchestrator ────────────────────────────────────────────
+
+async def core_pipeline(source: AsyncIterator[dict], job, http_client) -> dict:
+    """Chain all pipeline stages and execute the import.
+
+    Pipeline:
+        source → existence_filter → vendor_transform → flatten
+        → user_transform → flatten → dedupe → existence_filter_2
+        → helper_transforms → compute_sizes → smart_batcher → send_batches
+    """
+    # Chain stages
+    s1 = existence_filter(source, job)
+    s2 = vendor_transform(s1, job)
+    s3 = flatten_stream(s2, job)
+    s4 = user_transform(s3, job)
+    s5 = flatten_stream(s4, job)
+    s6 = dedupe_transform(s5, job)
+    s7 = post_transform_filter(s6, job)  # Post-transform existence check
+    s8 = helper_transforms(s7, job)
+    s9 = compute_sizes(s8, job)
+    s10 = smart_batcher(s9, job)
+
+    # Send batches with concurrent workers
+    await send_batches(s10, job, http_client)
+
+    if getattr(job, "_progress_written", False):
+        try:
+            job.progress_callback(job)
+        except Exception:
+            pass
+        print(flush=True)
+
+    return job.summary()

--- a/src/mixpanel_utils/streaming/core/pipeline.py
+++ b/src/mixpanel_utils/streaming/core/pipeline.py
@@ -1,8 +1,10 @@
 """Async generator pipeline for streaming data through transforms to Mixpanel.
 
-Each stage is an async generator: async def stage(source, job) -> AsyncIterator
+Each stage is an async generator: async def stage(source, job) -> AsyncIterator.
 Stages are chained together and consume records lazily with natural backpressure.
 """
+
+from __future__ import annotations
 
 import asyncio
 import json

--- a/src/mixpanel_utils/streaming/core/pipeline.py
+++ b/src/mixpanel_utils/streaming/core/pipeline.py
@@ -136,7 +136,10 @@ async def helper_transforms(source: AsyncIterator[dict], job) -> AsyncIterator[d
         skip = False
         for fn in transforms:
             result = fn(record)
-            if result is None or (isinstance(result, dict) and len(result) == 0):
+            if result is None:
+                skip = True
+                break
+            if isinstance(result, dict) and len(result) == 0:
                 job.empty += 1
                 skip = True
                 break

--- a/src/mixpanel_utils/streaming/core/pipeline.py
+++ b/src/mixpanel_utils/streaming/core/pipeline.py
@@ -15,12 +15,8 @@ logger = logging.getLogger(__name__)
 
 
 def _is_not_empty(data) -> bool:
-    if data is None:
-        return False
     if not isinstance(data, (dict, list)):
         return False
-    if isinstance(data, list):
-        return len(data) > 0
     return len(data) > 0
 
 
@@ -58,7 +54,7 @@ async def vendor_transform(source: AsyncIterator[dict], job) -> AsyncIterator[di
         if result is None:
             job.empty += 1
         elif isinstance(result, list):
-            yield result  # Will be flattened downstream
+            yield result
         elif _is_not_empty(result):
             yield result
         else:
@@ -94,7 +90,7 @@ async def user_transform(source: AsyncIterator[dict], job) -> AsyncIterator[dict
         if result is None:
             job.empty += 1
         elif isinstance(result, list):
-            yield result  # Will be flattened downstream
+            yield result
         elif _is_not_empty(result):
             yield result
         else:
@@ -244,7 +240,6 @@ async def send_batches(batches: AsyncIterator[list[dict]], job, http_client):
         tasks.add(task)
         task.add_done_callback(tasks.discard)
 
-        # Check for errors
         if errors:
             logger.error(f"Stopping due to errors: {errors}")
             break

--- a/src/mixpanel_utils/streaming/io/__init__.py
+++ b/src/mixpanel_utils/streaming/io/__init__.py
@@ -1,0 +1,1 @@
+"""I/O: input parsing, HTTP client, and exporters."""

--- a/src/mixpanel_utils/streaming/io/exporters.py
+++ b/src/mixpanel_utils/streaming/io/exporters.py
@@ -11,8 +11,6 @@ import logging
 from pathlib import Path
 from typing import AsyncIterator
 
-import httpx
-
 logger = logging.getLogger(__name__)
 
 
@@ -42,6 +40,8 @@ async def export_events(filename: str, job) -> list | str:
     all_results = []
     max_retries = job.max_retries or 5
     retry_count = 0
+
+    import httpx
 
     while retry_count <= max_retries:
         try:
@@ -173,6 +173,8 @@ async def export_profiles(folder: str, job) -> list:
     entity_name = "group" if job.data_group_id else "users"
     all_results = []
     iterations = 0
+
+    import httpx
 
     async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
         # First request
@@ -306,6 +308,8 @@ async def stream_events(job) -> AsyncIterator[dict]:
     if job.auth:
         headers["Authorization"] = job.auth
 
+    import httpx
+
     async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
         async with client.stream("GET", job.url, params=params, headers=headers) as response:
             response.raise_for_status()
@@ -349,6 +353,8 @@ async def stream_profiles(job) -> AsyncIterator[dict]:
     page = 0
     session_id = None
 
+    import httpx
+
     async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
         while True:
             params["page"] = page
@@ -386,11 +392,13 @@ async def stream_profiles(job) -> AsyncIterator[dict]:
 # ── Helpers ─────────────────────────────────────────────────────────
 
 async def _profile_request(
-    client: httpx.AsyncClient, url: str, headers: dict,
+    client, url: str, headers: dict,
     params: dict, body: str | None, job,
     max_retries: int = 5,
-) -> httpx.Response:
+):
     """Make a profile export request with retry logic."""
+    import httpx
+
     for attempt in range(max_retries + 1):
         try:
             response = await client.post(url, headers=headers, params=params, content=body)

--- a/src/mixpanel_utils/streaming/io/exporters.py
+++ b/src/mixpanel_utils/streaming/io/exporters.py
@@ -1,0 +1,445 @@
+"""Export operations: events, profiles, groups, annotations, and delete profiles.
+
+These functions call Mixpanel's export APIs and write results to local files or return them.
+"""
+
+import asyncio
+import json
+import logging
+from pathlib import Path
+from typing import AsyncIterator
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+async def export_events(filename: str, job) -> list | str:
+    """Export events from Mixpanel's raw export API.
+
+    Streams NDJSON from /api/2.0/export and writes to local file or returns records.
+    """
+    skip_write = job.dry_run or not filename
+
+    params = {
+        "from_date": job.start,
+        "to_date": job.end,
+        **(job.params or {}),
+    }
+    if job.limit:
+        params["limit"] = job.limit
+    if job.where_clause:
+        params["where"] = job.where_clause
+    if job.project and job.acct and job.pass_:
+        params["project_id"] = job.project
+
+    headers = {}
+    if job.auth:
+        headers["Authorization"] = job.auth
+
+    all_results = []
+    max_retries = job.max_retries or 5
+    retry_count = 0
+
+    while retry_count <= max_retries:
+        try:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
+                async with client.stream(
+                    "GET",
+                    job.url,
+                    params=params,
+                    headers=headers,
+                ) as response:
+                    job.requests += 1
+
+                    if response.status_code == 429:
+                        job.rate_limited += 1
+                        if retry_count < max_retries:
+                            backoff = min(30 * (2 ** retry_count), 300)
+                            logger.warning(f"Export rate limited (429). Retrying in {backoff}s...")
+                            await asyncio.sleep(backoff)
+                            retry_count += 1
+                            continue
+                        raise Exception(f"Export rate limited after {max_retries} retries")
+
+                    response.raise_for_status()
+
+                    if skip_write:
+                        # Collect all results in memory
+                        async for line in response.aiter_lines():
+                            line = line.strip()
+                            if not line:
+                                continue
+                            try:
+                                record = json.loads(line)
+                                if job.transform_func:
+                                    try:
+                                        transformed = job.transform_func(record)
+                                        if isinstance(transformed, list):
+                                            all_results.extend(transformed)
+                                        elif transformed:
+                                            all_results.append(transformed)
+                                    except Exception:
+                                        all_results.append(record)
+                                else:
+                                    all_results.append(record)
+                            except json.JSONDecodeError:
+                                pass
+                    else:
+                        # Write to file
+                        path = Path(filename)
+                        path.parent.mkdir(parents=True, exist_ok=True)
+                        with open(path, "w", encoding="utf-8") as f:
+                            record_count = 0
+                            async for line in response.aiter_lines():
+                                line = line.strip()
+                                if not line:
+                                    continue
+                                try:
+                                    record = json.loads(line)
+                                    if job.transform_func:
+                                        try:
+                                            transformed = job.transform_func(record)
+                                            if isinstance(transformed, list):
+                                                for item in transformed:
+                                                    f.write(json.dumps(item) + "\n")
+                                                    record_count += 1
+                                            elif transformed:
+                                                f.write(json.dumps(transformed) + "\n")
+                                                record_count += 1
+                                        except Exception:
+                                            f.write(json.dumps(record) + "\n")
+                                            record_count += 1
+                                    else:
+                                        f.write(line + "\n")
+                                        record_count += 1
+                                except json.JSONDecodeError:
+                                    pass
+
+            break  # Success
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 429:
+                continue  # Already handled above
+            logger.error(f"Export HTTP error: {e}")
+            job.store({"error": str(e)}, False)
+            break
+        except Exception as e:
+            logger.error(f"Export error: {e}")
+            job.store({"error": str(e)}, False)
+            break
+
+    if skip_write:
+        job.records_processed += len(all_results)
+        job.success += len(all_results)
+        job.dry_run_results.extend(all_results)
+        return all_results
+    else:
+        job.records_processed += record_count
+        job.success += record_count
+        return filename
+
+
+async def export_profiles(folder: str, job) -> list:
+    """Export user/group profiles from Mixpanel's engage API.
+
+    Paginates through all profiles and writes each page to a separate JSON file,
+    or returns all profiles in memory if dry_run.
+    """
+    skip_write = job.dry_run or not folder
+
+    headers = {}
+    if job.auth:
+        headers["Authorization"] = job.auth
+        headers["content-type"] = "application/x-www-form-urlencoded"
+
+    params = dict(job.params or {})
+    if job.project and job.acct and job.pass_:
+        params["project_id"] = job.project
+
+    # Build form body
+    form_parts = {}
+    if job.cohort_id:
+        form_parts["filter_by_cohort"] = json.dumps({"id": job.cohort_id})
+        form_parts["include_all_users"] = "false"
+    if job.where_clause:
+        form_parts["where"] = job.where_clause
+    if job.data_group_id:
+        form_parts["data_group_id"] = job.data_group_id
+
+    body = "&".join(f"{k}={v}" for k, v in form_parts.items()) if form_parts else None
+
+    entity_name = "group" if job.data_group_id else "users"
+    all_results = []
+    iterations = 0
+
+    async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
+        # First request
+        response = await _profile_request(client, job.url, headers, params, body, job)
+        data = response.json()
+
+        page = data.get("page", 0)
+        page_size = data.get("page_size", 1000)
+        session_id = data.get("session_id")
+        profiles = data.get("results", [])
+
+        # Apply transforms
+        profiles = _apply_transforms(profiles, job)
+
+        if skip_write:
+            all_results.extend(profiles)
+        else:
+            filepath = _profile_filepath(folder, entity_name, iterations)
+            _write_jsonl(filepath, profiles)
+            all_results.append(filepath)
+
+        job.records_processed += len(profiles)
+        job.success += len(profiles)
+        job.requests += 1
+
+        last_num_results = len(data.get("results", []))
+
+        # Paginate
+        while last_num_results >= page_size:
+            page += 1
+            iterations += 1
+            params["page"] = page
+            params["session_id"] = session_id
+
+            response = await _profile_request(client, job.url, headers, params, body, job)
+            data = response.json()
+
+            job.requests += 1
+            profiles = data.get("results", [])
+            profiles = _apply_transforms(profiles, job)
+
+            job.records_processed += len(profiles)
+            job.success += len(profiles)
+
+            if skip_write:
+                all_results.extend(profiles)
+            else:
+                filepath = _profile_filepath(folder, entity_name, iterations)
+                _write_jsonl(filepath, profiles)
+                all_results.append(filepath)
+
+            last_num_results = len(data.get("results", []))
+
+    if skip_write:
+        job.dry_run_results.extend(all_results)
+
+    return all_results
+
+
+async def delete_profiles(job) -> dict:
+    """Delete all user or group profiles from a Mixpanel project.
+
+    First exports all profiles, then sends delete requests via the import pipeline.
+    """
+    from .. import mp_import
+
+    if not job.token:
+        raise ValueError("Token required for profile deletion")
+
+    entity_type = "user"
+    delete_key = "$distinct_id"
+    export_opts = {
+        "record_type": "profile-export",
+        "dry_run": True,
+        "verbose": False,
+    }
+
+    if job.data_group_id:
+        entity_type = "group"
+        export_opts["data_group_id"] = job.data_group_id
+        if job.group_key:
+            delete_key = job.group_key
+        else:
+            raise ValueError("group_key required for group profile deletion")
+
+    creds = {"acct": job.acct, "pass": job.pass_, "project": job.project, "secret": job.secret}
+    creds = {k: v for k, v in creds.items() if v}
+
+    # Export all profiles first
+    export_result = await mp_import(creds, None, export_opts)
+    exported_profiles = export_result.get("dry_run", [])
+
+    # Build delete objects
+    delete_objects = []
+    for profile in exported_profiles:
+        delete_obj = {
+            "$token": job.token,
+            "$delete": "null",
+        }
+        if entity_type == "user":
+            delete_obj["$ignore_alias"] = False
+            delete_obj["$distinct_id"] = profile.get("$distinct_id", "")
+        elif entity_type == "group":
+            delete_obj["$group_key"] = delete_key
+            delete_obj["$group_id"] = profile.get("$distinct_id", "")
+        delete_objects.append(delete_obj)
+
+    # Send deletes
+    delete_opts = {"record_type": entity_type}
+    if job.group_key:
+        delete_opts["group_key"] = job.group_key
+
+    delete_result = await mp_import({"token": job.token}, delete_objects, delete_opts)
+    return delete_result
+
+
+async def stream_events(job) -> AsyncIterator[dict]:
+    """Stream events from Mixpanel's export API as an async iterator of dicts."""
+    params = {
+        "from_date": job.start,
+        "to_date": job.end,
+    }
+    if job.limit:
+        params["limit"] = job.limit
+    if job.where_clause:
+        params["where"] = job.where_clause
+    if job.project and job.acct and job.pass_:
+        params["project_id"] = job.project
+
+    headers = {}
+    if job.auth:
+        headers["Authorization"] = job.auth
+
+    async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
+        async with client.stream("GET", job.url, params=params, headers=headers) as response:
+            response.raise_for_status()
+            async for line in response.aiter_lines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                    # Flatten properties to top level (like Node version)
+                    if "properties" in record:
+                        flat = {**record, **record["properties"]}
+                        del flat["properties"]
+                        yield flat
+                    else:
+                        yield record
+                except json.JSONDecodeError:
+                    pass
+
+
+async def stream_profiles(job) -> AsyncIterator[dict]:
+    """Stream profiles from Mixpanel's engage API as an async iterator of dicts."""
+    headers = {}
+    if job.auth:
+        headers["Authorization"] = job.auth
+        headers["content-type"] = "application/x-www-form-urlencoded"
+
+    params = dict(job.params or {})
+    if job.project and job.acct and job.pass_:
+        params["project_id"] = job.project
+
+    form_parts = {}
+    if job.cohort_id:
+        form_parts["filter_by_cohort"] = json.dumps({"id": job.cohort_id})
+        form_parts["include_all_users"] = "true"
+    if job.data_group_id:
+        form_parts["data_group_id"] = job.data_group_id
+
+    body = "&".join(f"{k}={v}" for k, v in form_parts.items()) if form_parts else None
+
+    page = 0
+    session_id = None
+
+    async with httpx.AsyncClient(timeout=httpx.Timeout(120.0, connect=10.0)) as client:
+        while True:
+            params["page"] = page
+            if session_id:
+                params["session_id"] = session_id
+
+            response = await client.post(
+                job.url, headers=headers, params=params,
+                content=body,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            session_id = data.get("session_id")
+            page_size = data.get("page_size", 1000)
+            results = data.get("results", [])
+
+            if not results:
+                break
+
+            for profile in results:
+                # Flatten $properties to top level
+                flat = {**profile}
+                if "$properties" in flat:
+                    flat.update(flat["$properties"])
+                    del flat["$properties"]
+                yield flat
+
+            if len(results) < page_size:
+                break
+
+            page += 1
+
+
+# ── Helpers ─────────────────────────────────────────────────────────
+
+async def _profile_request(
+    client: httpx.AsyncClient, url: str, headers: dict,
+    params: dict, body: str | None, job,
+    max_retries: int = 5,
+) -> httpx.Response:
+    """Make a profile export request with retry logic."""
+    for attempt in range(max_retries + 1):
+        try:
+            response = await client.post(url, headers=headers, params=params, content=body)
+            if response.status_code == 429:
+                job.rate_limited += 1
+                if attempt < max_retries:
+                    backoff = min(30 * (2 ** attempt), 300)
+                    logger.warning(f"Profile export rate limited. Retrying in {backoff}s...")
+                    await asyncio.sleep(backoff)
+                    continue
+                raise Exception(f"Profile export rate limited after {max_retries} retries")
+            response.raise_for_status()
+            return response
+        except httpx.HTTPStatusError:
+            raise
+        except Exception as e:
+            if attempt < max_retries:
+                backoff = min(30 * (2 ** attempt), 300)
+                await asyncio.sleep(backoff)
+                continue
+            raise
+
+    raise Exception("Profile request failed after all retries")
+
+
+def _profile_filepath(folder: str, entity_name: str, iteration: int) -> str:
+    """Build a profile export file path."""
+    path = Path(folder)
+    path.mkdir(parents=True, exist_ok=True)
+    return str(path / f"{entity_name}-{iteration}.json")
+
+
+def _write_jsonl(filepath: str, data: list):
+    """Write a list of dicts as JSONL."""
+    with open(filepath, "w", encoding="utf-8") as f:
+        for item in data:
+            f.write(json.dumps(item) + "\n")
+
+
+def _apply_transforms(records: list, job) -> list:
+    """Apply user transform function to a list of records."""
+    if not job.transform_func:
+        return records
+    result = []
+    for record in records:
+        try:
+            transformed = job.transform_func(record)
+            if isinstance(transformed, list):
+                result.extend(transformed)
+            elif transformed:
+                result.append(transformed)
+        except Exception:
+            result.append(record)
+    return result

--- a/src/mixpanel_utils/streaming/io/exporters.py
+++ b/src/mixpanel_utils/streaming/io/exporters.py
@@ -3,6 +3,8 @@
 These functions call Mixpanel's export APIs and write results to local files or return them.
 """
 
+from __future__ import annotations
+
 import asyncio
 import json
 import logging

--- a/src/mixpanel_utils/streaming/io/exporters.py
+++ b/src/mixpanel_utils/streaming/io/exporters.py
@@ -38,6 +38,7 @@ async def export_events(filename: str, job) -> list | str:
         headers["Authorization"] = job.auth
 
     all_results = []
+    record_count = 0
     max_retries = job.max_retries or 5
     retry_count = 0
 

--- a/src/mixpanel_utils/streaming/io/http_client.py
+++ b/src/mixpanel_utils/streaming/io/http_client.py
@@ -1,5 +1,7 @@
 """HTTP client for sending data to Mixpanel APIs."""
 
+from __future__ import annotations
+
 import asyncio
 import gzip
 import json

--- a/src/mixpanel_utils/streaming/io/http_client.py
+++ b/src/mixpanel_utils/streaming/io/http_client.py
@@ -1,0 +1,153 @@
+"""HTTP client for sending data to Mixpanel APIs."""
+
+import asyncio
+import gzip
+import json
+import logging
+from urllib.parse import urlparse
+from typing import Any
+
+import httpx
+
+from ..constants import RETRY_STATUS_CODES, GZIP_RECORD_TYPES
+
+logger = logging.getLogger(__name__)
+
+
+class MixpanelHttpClient:
+    """Manages httpx connection pools and sends batches to Mixpanel."""
+
+    def __init__(self):
+        limits = httpx.Limits(
+            max_connections=100,
+            max_keepalive_connections=50,
+            keepalive_expiry=30.0,
+        )
+        timeout = httpx.Timeout(60.0, connect=10.0)
+        self._pools: dict[str, httpx.AsyncClient] = {}
+        self._limits = limits
+        self._timeout = timeout
+
+    def _get_client(self, base_url: str) -> httpx.AsyncClient:
+        if base_url not in self._pools:
+            self._pools[base_url] = httpx.AsyncClient(
+                base_url=base_url,
+                limits=self._limits,
+                timeout=self._timeout,
+                http2=False,
+            )
+        return self._pools[base_url]
+
+    async def send_batch(self, batch: list[dict], job) -> tuple[dict, bool]:
+        """Send a batch of records to Mixpanel. Returns (response_dict, success_bool)."""
+        body_bytes = json.dumps(batch).encode("utf-8")
+
+        headers = {
+            "Authorization": job.auth,
+            "Content-Type": job.content_type,
+            "Accept": "application/json",
+            "Connection": "keep-alive",
+        }
+
+        # Gzip compress for events/scd
+        encoding = ""
+        if job.record_type in GZIP_RECORD_TYPES and job.compress:
+            body_bytes = gzip.compress(body_bytes, compresslevel=job.compression_level)
+            headers["Content-Encoding"] = "gzip"
+            encoding = "gzip"
+
+        params: dict[str, Any] = {
+            "ip": "0",
+            "verbose": "1",
+            "strict": str(int(job.strict)),
+        }
+        if job.project and not job.secret:
+            params["project_id"] = job.project
+
+        parsed = urlparse(job.url)
+        base_url = f"{parsed.scheme}://{parsed.netloc}"
+        path = parsed.path
+        client = self._get_client(base_url)
+
+        for attempt in range(job.max_retries + 1):
+            try:
+                resp = await client.request(
+                    method=job.req_method,
+                    url=path,
+                    params=params,
+                    content=body_bytes,
+                    headers=headers,
+                )
+
+                if resp.status_code in RETRY_STATUS_CODES and attempt < job.max_retries:
+                    job.retries += 1
+                    job.requests += 1
+                    if resp.status_code == 429:
+                        job.rate_limited += 1
+                    elif str(resp.status_code).startswith("5"):
+                        job.server_errors += 1
+                    else:
+                        job.client_errors += 1
+                    delay = min(2 ** attempt, 30)
+                    if job.verbose:
+                        logger.info(f"Retry #{attempt + 1} after {delay}s (status {resp.status_code})")
+                    await asyncio.sleep(delay)
+                    continue
+
+                try:
+                    data = resp.json()
+                except Exception:
+                    data = {"error": resp.text, "status": False, "status_code": resp.status_code}
+
+                success = 200 <= resp.status_code < 300
+                return data, success
+
+            except (httpx.ConnectError, httpx.ReadTimeout, httpx.WriteTimeout,
+                    httpx.PoolTimeout, httpx.ConnectTimeout) as e:
+                if attempt < job.max_retries:
+                    job.retries += 1
+                    job.requests += 1
+                    job.client_errors += 1
+                    delay = min(2 ** attempt, 30)
+                    if job.verbose:
+                        logger.info(f"Retry #{attempt + 1} after {delay}s ({type(e).__name__})")
+                    await asyncio.sleep(delay)
+                    continue
+                return {"error": str(e), "status": False}, False
+
+        return {"error": "max retries exceeded", "status": False}, False
+
+    async def send_table(self, csv_data: str, job) -> tuple[dict, bool]:
+        """Send lookup table data (CSV) to Mixpanel."""
+        headers = {
+            "Authorization": job.auth,
+            "Content-Type": "text/csv",
+            "Accept": "application/json",
+        }
+
+        parsed = urlparse(job.url)
+        base_url = f"{parsed.scheme}://{parsed.netloc}"
+        path = parsed.path
+        client = self._get_client(base_url)
+
+        try:
+            resp = await client.request(
+                method="PUT",
+                url=path,
+                content=csv_data.encode("utf-8"),
+                headers=headers,
+            )
+            try:
+                data = resp.json()
+            except Exception:
+                data = {"error": resp.text, "status": False}
+            success = 200 <= resp.status_code < 300
+            return data, success
+        except Exception as e:
+            return {"error": str(e), "status": False}, False
+
+    async def close(self):
+        """Close all connection pools."""
+        for client in self._pools.values():
+            await client.aclose()
+        self._pools.clear()

--- a/src/mixpanel_utils/streaming/io/http_client.py
+++ b/src/mixpanel_utils/streaming/io/http_client.py
@@ -83,7 +83,6 @@ class MixpanelHttpClient:
 
                 if resp.status_code in RETRY_STATUS_CODES and attempt < job.max_retries:
                     job.retries += 1
-                    job.requests += 1
                     if resp.status_code == 429:
                         job.rate_limited += 1
                     elif str(resp.status_code).startswith("5"):
@@ -108,7 +107,6 @@ class MixpanelHttpClient:
                     httpx.PoolTimeout, httpx.ConnectTimeout) as e:
                 if attempt < job.max_retries:
                     job.retries += 1
-                    job.requests += 1
                     job.client_errors += 1
                     delay = min(2 ** attempt, 30)
                     if job.verbose:

--- a/src/mixpanel_utils/streaming/io/http_client.py
+++ b/src/mixpanel_utils/streaming/io/http_client.py
@@ -51,12 +51,9 @@ class MixpanelHttpClient:
             "Connection": "keep-alive",
         }
 
-        # Gzip compress for events/scd
-        encoding = ""
         if job.record_type in GZIP_RECORD_TYPES and job.compress:
             body_bytes = gzip.compress(body_bytes, compresslevel=job.compression_level)
             headers["Content-Encoding"] = "gzip"
-            encoding = "gzip"
 
         params: dict[str, Any] = {
             "ip": "0",

--- a/src/mixpanel_utils/streaming/io/parsers.py
+++ b/src/mixpanel_utils/streaming/io/parsers.py
@@ -1,0 +1,455 @@
+"""Input detection and format-specific readers.
+
+All readers return AsyncIterator[dict] for consistent pipeline consumption.
+"""
+
+import asyncio
+import csv
+import gzip
+import io
+import json
+import logging
+from pathlib import Path
+from typing import AsyncIterator, Any
+
+from ..constants import (
+    JSONL_EXTENSIONS, JSON_EXTENSIONS, CSV_EXTENSIONS,
+    PARQUET_EXTENSIONS, GZIP_EXTENSIONS,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def detect_format(path: Path, job=None) -> str:
+    """Detect file format from extension."""
+    suffixes = path.suffixes
+    # Handle compound extensions like .json.gz
+    is_gzipped = suffixes and suffixes[-1].lower() in GZIP_EXTENSIONS
+    base_ext = suffixes[-2].lower() if is_gzipped and len(suffixes) > 1 else (suffixes[-1].lower() if suffixes else "")
+
+    if job and job.stream_format:
+        fmt = job.stream_format.lower()
+        if fmt in ("jsonl", "ndjson"):
+            return "jsonl"
+        if fmt in ("json", "strict_json"):
+            return "json"
+        if fmt in ("csv", "tsv"):
+            return "csv"
+        if fmt == "parquet":
+            return "parquet"
+
+    if base_ext in JSONL_EXTENSIONS:
+        return "jsonl"
+    if base_ext in JSON_EXTENSIONS:
+        return "json"
+    if base_ext in CSV_EXTENSIONS:
+        return "csv"
+    if base_ext in PARQUET_EXTENSIONS:
+        return "parquet"
+
+    # Default to jsonl
+    return "jsonl"
+
+
+def is_gzipped(path: Path, job=None) -> bool:
+    """Check if file is gzipped."""
+    if job and job.is_gzip:
+        return True
+    suffixes = path.suffixes
+    return bool(suffixes and suffixes[-1].lower() in GZIP_EXTENSIONS)
+
+
+async def resolve_input(data: Any, job) -> AsyncIterator[dict]:
+    """Detect data type and return an async iterator of records."""
+    # List or tuple of dicts
+    if isinstance(data, (list, tuple)):
+        return _iter_list(data)
+
+    # Async iterable
+    if hasattr(data, "__aiter__"):
+        return data
+
+    # Sync iterable (generator, etc.) but not string
+    if hasattr(data, "__iter__") and not isinstance(data, (str, bytes)):
+        return _wrap_sync_iter(data)
+
+    # String: file path, directory, glob, or cloud URL
+    if isinstance(data, str):
+        if data.startswith("gs://"):
+            return _gcs_stream(data, job)
+        if data.startswith("s3://"):
+            return _s3_stream(data, job)
+
+        path = Path(data)
+        if path.exists():
+            if path.is_dir():
+                return _multi_file_stream(sorted(path.iterdir()), job)
+            return _file_stream(path, job)
+
+        # Try glob
+        import glob as glob_mod
+        files = sorted(glob_mod.glob(data))
+        if files:
+            return _multi_file_stream([Path(f) for f in files], job)
+
+        # Try parsing as inline JSON
+        return _parse_string_data(data, job)
+
+    raise ValueError(f"Cannot determine data type for {type(data)}")
+
+
+async def _iter_list(data: list) -> AsyncIterator[dict]:
+    for item in data:
+        yield item
+
+
+async def _wrap_sync_iter(data) -> AsyncIterator[dict]:
+    for item in data:
+        yield item
+
+
+async def _file_stream(path: Path, job) -> AsyncIterator[dict]:
+    """Stream records from a single file."""
+    fmt = detect_format(path, job)
+    gz = is_gzipped(path, job)
+
+    if fmt == "jsonl":
+        async for record in _jsonl_reader(path, gz, job):
+            yield record
+    elif fmt == "json":
+        async for record in _json_reader(path, gz, job):
+            yield record
+    elif fmt == "csv":
+        async for record in _csv_reader(path, gz, job):
+            yield record
+    elif fmt == "parquet":
+        async for record in _parquet_reader(path, job):
+            yield record
+
+
+async def _multi_file_stream(paths: list[Path], job) -> AsyncIterator[dict]:
+    """Stream records from multiple files sequentially."""
+    for path in paths:
+        if path.is_file():
+            async for record in _file_stream(path, job):
+                yield record
+
+
+def _open_file(path: Path, gzipped: bool):
+    """Open a file, with optional gzip decompression."""
+    if gzipped:
+        return gzip.open(str(path), "rt", encoding="utf-8")
+    return open(str(path), "r", encoding="utf-8")
+
+
+async def _jsonl_reader(path: Path, gzipped: bool, job) -> AsyncIterator[dict]:
+    """Read JSONL/NDJSON file line by line."""
+    loop = asyncio.get_event_loop()
+
+    def _read_lines():
+        results = []
+        with _open_file(path, gzipped) as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    try:
+                        results.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        job.unparsable += 1
+        return results
+
+    records = await loop.run_in_executor(None, _read_lines)
+    for record in records:
+        yield record
+
+
+async def _json_reader(path: Path, gzipped: bool, job) -> AsyncIterator[dict]:
+    """Read a JSON array file. Falls back to JSONL if JSON array parsing fails."""
+    loop = asyncio.get_event_loop()
+
+    def _read_json():
+        with _open_file(path, gzipped) as f:
+            content = f.read()
+        # Try as JSON array/object first
+        try:
+            data = json.loads(content)
+            if isinstance(data, list):
+                return data
+            if isinstance(data, dict):
+                return [data]
+            return []
+        except json.JSONDecodeError:
+            pass
+        # Fall back to JSONL (one JSON object per line)
+        results = []
+        for line in content.strip().split("\n"):
+            line = line.strip()
+            if line:
+                try:
+                    results.append(json.loads(line))
+                except json.JSONDecodeError:
+                    job.unparsable += 1
+        return results
+
+    records = await loop.run_in_executor(None, _read_json)
+    for record in records:
+        yield record
+
+
+async def _csv_reader(path: Path, gzipped: bool, job) -> AsyncIterator[dict]:
+    """Read CSV file, yielding dicts with headers as keys."""
+    loop = asyncio.get_event_loop()
+
+    def _read_csv():
+        results = []
+        with _open_file(path, gzipped) as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                # Strip whitespace from keys
+                cleaned = {k.strip(): v for k, v in row.items() if k}
+                results.append(cleaned)
+        return results
+
+    records = await loop.run_in_executor(None, _read_csv)
+    for record in records:
+        yield record
+
+
+async def _parquet_reader(path: Path, job) -> AsyncIterator[dict]:
+    """Read Parquet file using pyarrow."""
+    loop = asyncio.get_event_loop()
+
+    def _read_parquet():
+        import pyarrow.parquet as pq
+        from datetime import date, datetime
+        table = pq.read_table(str(path))
+        results = []
+        for batch in table.to_batches(max_chunksize=1000):
+            for row in batch.to_pylist():
+                record = {}
+                for k, v in row.items():
+                    if v is None:
+                        continue
+                    if isinstance(v, datetime):
+                        record[k] = v.isoformat()
+                    elif isinstance(v, date):
+                        record[k] = v.isoformat()
+                    else:
+                        record[k] = v
+                results.append(record)
+        return results
+
+    records = await loop.run_in_executor(None, _read_parquet)
+    for record in records:
+        yield record
+
+
+async def _parse_string_data(data: str, job) -> AsyncIterator[dict]:
+    """Try to parse a string as JSON or JSONL."""
+    data = data.strip()
+    # Try JSON array
+    if data.startswith("["):
+        try:
+            items = json.loads(data)
+            if isinstance(items, list):
+                for item in items:
+                    yield item
+                return
+        except json.JSONDecodeError:
+            pass
+
+    # Try JSON object
+    if data.startswith("{"):
+        try:
+            item = json.loads(data)
+            yield item
+            return
+        except json.JSONDecodeError:
+            pass
+
+    # Try JSONL (multiple lines)
+    for line in data.split("\n"):
+        line = line.strip()
+        if line:
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError:
+                job.unparsable += 1
+
+
+# ── Cloud Storage ────────────────────────────────────────────────────
+
+async def _gcs_stream(uri: str, job) -> AsyncIterator[dict]:
+    """Stream records from Google Cloud Storage."""
+    try:
+        import gcsfs
+    except ImportError:
+        raise ImportError('Install gcsfs for GCS support: pip install "mixpanel-utils[streaming-gcs]"')
+
+    # Parse gs://bucket/path
+    parts = uri.replace("gs://", "").split("/", 1)
+    bucket = parts[0]
+    key = parts[1] if len(parts) > 1 else ""
+
+    fs = gcsfs.GCSFileSystem(
+        project=job.gcp_project_id or None,
+        token=job.gcs_credentials or "google_default",
+    )
+
+    path = Path(key)
+    fmt = detect_format(path, job)
+    gz = is_gzipped(path, job)
+
+    loop = asyncio.get_event_loop()
+
+    def _read():
+        results = []
+
+        # Parquet: read as binary, don't decode to text
+        if fmt == "parquet":
+            import pyarrow.parquet as pq
+            from datetime import date, datetime as dt_cls
+            with fs.open(uri, "rb") as f:
+                table = pq.read_table(f)
+            for batch in table.to_batches(max_chunksize=1000):
+                for row in batch.to_pylist():
+                    record = {}
+                    for k, v in row.items():
+                        if v is None:
+                            continue
+                        if isinstance(v, dt_cls):
+                            record[k] = v.isoformat()
+                        elif isinstance(v, date):
+                            record[k] = v.isoformat()
+                        else:
+                            record[k] = v
+                    results.append(record)
+            return results
+
+        with fs.open(uri, "rb") as f:
+            if gz:
+                raw = gzip.decompress(f.read())
+                text = raw.decode("utf-8")
+            else:
+                raw = f.read()
+                text = raw.decode("utf-8") if isinstance(raw, bytes) else raw
+
+        if fmt == "jsonl":
+            for line in text.strip().split("\n"):
+                line = line.strip()
+                if line:
+                    try:
+                        results.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        job.unparsable += 1
+        elif fmt == "json":
+            try:
+                data = json.loads(text)
+                if isinstance(data, list):
+                    results = data
+                else:
+                    results = [data]
+            except json.JSONDecodeError:
+                # Fall back to JSONL
+                for line in text.strip().split("\n"):
+                    line = line.strip()
+                    if line:
+                        try:
+                            results.append(json.loads(line))
+                        except json.JSONDecodeError:
+                            job.unparsable += 1
+        elif fmt == "csv":
+            reader = csv.DictReader(io.StringIO(text))
+            for row in reader:
+                results.append({k.strip(): v for k, v in row.items() if k})
+        return results
+
+    records = await loop.run_in_executor(None, _read)
+    for record in records:
+        yield record
+
+
+async def _s3_stream(uri: str, job) -> AsyncIterator[dict]:
+    """Stream records from Amazon S3."""
+    try:
+        import boto3
+    except ImportError:
+        raise ImportError('Install boto3 for S3 support: pip install "mixpanel-utils[streaming-s3]"')
+
+    parts = uri.replace("s3://", "").split("/", 1)
+    bucket = parts[0]
+    key = parts[1] if len(parts) > 1 else ""
+
+    loop = asyncio.get_event_loop()
+
+    def _read():
+        kwargs = {}
+        if job.s3_key and job.s3_secret:
+            kwargs["aws_access_key_id"] = job.s3_key
+            kwargs["aws_secret_access_key"] = job.s3_secret
+        if job.s3_region:
+            kwargs["region_name"] = job.s3_region
+
+        s3 = boto3.client("s3", **kwargs)
+        response = s3.get_object(Bucket=bucket, Key=key)
+        body = response["Body"].read()
+
+        path = Path(key)
+        gz = is_gzipped(path, job)
+        fmt = detect_format(path, job)
+
+        if gz:
+            body = gzip.decompress(body)
+
+        results = []
+        if fmt == "parquet":
+            import pyarrow.parquet as pq
+            from datetime import date, datetime as dt_cls
+            table = pq.read_table(io.BytesIO(body))
+            for batch in table.to_batches(max_chunksize=1000):
+                for row in batch.to_pylist():
+                    record = {}
+                    for k, v in row.items():
+                        if v is None:
+                            continue
+                        if isinstance(v, dt_cls):
+                            record[k] = v.isoformat()
+                        elif isinstance(v, date):
+                            record[k] = v.isoformat()
+                        else:
+                            record[k] = v
+                    results.append(record)
+            return results
+
+        text = body.decode("utf-8")
+
+        if fmt == "jsonl":
+            for line in text.strip().split("\n"):
+                line = line.strip()
+                if line:
+                    try:
+                        results.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        job.unparsable += 1
+        elif fmt == "json":
+            try:
+                data = json.loads(text)
+                results = data if isinstance(data, list) else [data]
+            except json.JSONDecodeError:
+                # Fall back to JSONL
+                for line in text.strip().split("\n"):
+                    line = line.strip()
+                    if line:
+                        try:
+                            results.append(json.loads(line))
+                        except json.JSONDecodeError:
+                            job.unparsable += 1
+        elif fmt == "csv":
+            reader = csv.DictReader(io.StringIO(text))
+            for row in reader:
+                results.append({k.strip(): v for k, v in row.items() if k})
+        return results
+
+    records = await loop.run_in_executor(None, _read)
+    for record in records:
+        yield record

--- a/src/mixpanel_utils/streaming/io/parsers.py
+++ b/src/mixpanel_utils/streaming/io/parsers.py
@@ -3,6 +3,8 @@
 All readers return AsyncIterator[dict] for consistent pipeline consumption.
 """
 
+from __future__ import annotations
+
 import asyncio
 import csv
 import gzip

--- a/src/mixpanel_utils/streaming/io/parsers.py
+++ b/src/mixpanel_utils/streaming/io/parsers.py
@@ -1,6 +1,8 @@
 """Input detection and format-specific readers.
 
 All readers return AsyncIterator[dict] for consistent pipeline consumption.
+File readers use a bounded queue to bridge sync I/O threads with async generators,
+providing true streaming with backpressure — memory stays flat regardless of file size.
 """
 
 from __future__ import annotations
@@ -11,7 +13,9 @@ import gzip
 import io
 import json
 import logging
+import queue
 from pathlib import Path
+from threading import Thread
 from typing import AsyncIterator, Any
 
 from ..constants import (
@@ -21,6 +25,43 @@ from ..constants import (
 
 logger = logging.getLogger(__name__)
 
+_SENTINEL = object()
+
+
+# ── Queue-based sync→async bridge ────────────────────────────────────
+
+async def _stream_from_executor(sync_producer, *args) -> AsyncIterator[dict]:
+    """Bridge a blocking producer function into an async generator via a bounded queue.
+
+    sync_producer(q, *args) runs in a daemon thread and calls q.put(record)
+    for each record, then lets the wrapper put _SENTINEL when done.
+    The bounded queue (maxsize=1000) provides natural backpressure —
+    the reader thread blocks when the pipeline can't keep up.
+    """
+    q: queue.Queue = queue.Queue(maxsize=1000)
+    loop = asyncio.get_event_loop()
+
+    def _run():
+        try:
+            sync_producer(q, *args)
+        except Exception as e:
+            q.put(e)
+        finally:
+            q.put(_SENTINEL)
+
+    thread = Thread(target=_run, daemon=True)
+    thread.start()
+
+    while True:
+        item = await loop.run_in_executor(None, q.get)
+        if item is _SENTINEL:
+            break
+        if isinstance(item, Exception):
+            raise item
+        yield item
+
+
+# ── Format detection ─────────────────────────────────────────────────
 
 def detect_format(path: Path, job=None) -> str:
     """Detect file format from extension."""
@@ -60,6 +101,8 @@ def is_gzipped(path: Path, job=None) -> bool:
     suffixes = path.suffixes
     return bool(suffixes and suffixes[-1].lower() in GZIP_EXTENSIONS)
 
+
+# ── Input resolution ─────────────────────────────────────────────────
 
 async def resolve_input(data: Any, job) -> AsyncIterator[dict]:
     """Detect data type and return an async iterator of records."""
@@ -110,6 +153,8 @@ async def _wrap_sync_iter(data) -> AsyncIterator[dict]:
         yield item
 
 
+# ── File streaming ───────────────────────────────────────────────────
+
 async def _file_stream(path: Path, job) -> AsyncIterator[dict]:
     """Stream records from a single file."""
     fmt = detect_format(path, job)
@@ -144,88 +189,78 @@ def _open_file(path: Path, gzipped: bool):
     return open(str(path), "r", encoding="utf-8")
 
 
-async def _jsonl_reader(path: Path, gzipped: bool, job) -> AsyncIterator[dict]:
-    """Read JSONL/NDJSON file line by line."""
-    loop = asyncio.get_event_loop()
+# ── Format-specific readers ──────────────────────────────────────────
 
-    def _read_lines():
-        results = []
+async def _jsonl_reader(path: Path, gzipped: bool, job) -> AsyncIterator[dict]:
+    """Stream JSONL/NDJSON file line by line without loading into memory."""
+    def _produce(q, path, gzipped, job):
         with _open_file(path, gzipped) as f:
             for line in f:
                 line = line.strip()
                 if line:
                     try:
-                        results.append(json.loads(line))
+                        q.put(json.loads(line))
                     except json.JSONDecodeError:
                         job.unparsable += 1
-        return results
 
-    records = await loop.run_in_executor(None, _read_lines)
-    for record in records:
+    async for record in _stream_from_executor(_produce, path, gzipped, job):
         yield record
 
 
 async def _json_reader(path: Path, gzipped: bool, job) -> AsyncIterator[dict]:
-    """Read a JSON array file. Falls back to JSONL if JSON array parsing fails."""
-    loop = asyncio.get_event_loop()
+    """Read a JSON array file. Falls back to JSONL if JSON array parsing fails.
 
-    def _read_json():
+    Note: JSON arrays must be parsed whole, but records are streamed to the
+    pipeline immediately via the queue rather than waiting for all parsing.
+    """
+    def _produce(q, path, gzipped, job):
         with _open_file(path, gzipped) as f:
             content = f.read()
         # Try as JSON array/object first
         try:
             data = json.loads(content)
             if isinstance(data, list):
-                return data
+                for record in data:
+                    q.put(record)
+                return
             if isinstance(data, dict):
-                return [data]
-            return []
+                q.put(data)
+                return
+            return
         except json.JSONDecodeError:
             pass
         # Fall back to JSONL (one JSON object per line)
-        results = []
         for line in content.strip().split("\n"):
             line = line.strip()
             if line:
                 try:
-                    results.append(json.loads(line))
+                    q.put(json.loads(line))
                 except json.JSONDecodeError:
                     job.unparsable += 1
-        return results
 
-    records = await loop.run_in_executor(None, _read_json)
-    for record in records:
+    async for record in _stream_from_executor(_produce, path, gzipped, job):
         yield record
 
 
 async def _csv_reader(path: Path, gzipped: bool, job) -> AsyncIterator[dict]:
-    """Read CSV file, yielding dicts with headers as keys."""
-    loop = asyncio.get_event_loop()
-
-    def _read_csv():
-        results = []
+    """Stream CSV file row by row without loading into memory."""
+    def _produce(q, path, gzipped, job):
         with _open_file(path, gzipped) as f:
             reader = csv.DictReader(f)
             for row in reader:
-                # Strip whitespace from keys
                 cleaned = {k.strip(): v for k, v in row.items() if k}
-                results.append(cleaned)
-        return results
+                q.put(cleaned)
 
-    records = await loop.run_in_executor(None, _read_csv)
-    for record in records:
+    async for record in _stream_from_executor(_produce, path, gzipped, job):
         yield record
 
 
 async def _parquet_reader(path: Path, job) -> AsyncIterator[dict]:
-    """Read Parquet file using pyarrow."""
-    loop = asyncio.get_event_loop()
-
-    def _read_parquet():
+    """Stream Parquet file batch by batch without loading into memory."""
+    def _produce(q, path):
         import pyarrow.parquet as pq
         from datetime import date, datetime
         table = pq.read_table(str(path))
-        results = []
         for batch in table.to_batches(max_chunksize=1000):
             for row in batch.to_pylist():
                 record = {}
@@ -238,11 +273,9 @@ async def _parquet_reader(path: Path, job) -> AsyncIterator[dict]:
                         record[k] = v.isoformat()
                     else:
                         record[k] = v
-                results.append(record)
-        return results
+                q.put(record)
 
-    records = await loop.run_in_executor(None, _read_parquet)
-    for record in records:
+    async for record in _stream_from_executor(_produce, path):
         yield record
 
 
@@ -302,12 +335,7 @@ async def _gcs_stream(uri: str, job) -> AsyncIterator[dict]:
     fmt = detect_format(path, job)
     gz = is_gzipped(path, job)
 
-    loop = asyncio.get_event_loop()
-
-    def _read():
-        results = []
-
-        # Parquet: read as binary, don't decode to text
+    def _produce(q):
         if fmt == "parquet":
             import pyarrow.parquet as pq
             from datetime import date, datetime as dt_cls
@@ -325,8 +353,8 @@ async def _gcs_stream(uri: str, job) -> AsyncIterator[dict]:
                             record[k] = v.isoformat()
                         else:
                             record[k] = v
-                    results.append(record)
-            return results
+                    q.put(record)
+            return
 
         with fs.open(uri, "rb") as f:
             if gz:
@@ -341,33 +369,29 @@ async def _gcs_stream(uri: str, job) -> AsyncIterator[dict]:
                 line = line.strip()
                 if line:
                     try:
-                        results.append(json.loads(line))
+                        q.put(json.loads(line))
                     except json.JSONDecodeError:
                         job.unparsable += 1
         elif fmt == "json":
             try:
                 data = json.loads(text)
-                if isinstance(data, list):
-                    results = data
-                else:
-                    results = [data]
+                items = data if isinstance(data, list) else [data]
+                for item in items:
+                    q.put(item)
             except json.JSONDecodeError:
-                # Fall back to JSONL
                 for line in text.strip().split("\n"):
                     line = line.strip()
                     if line:
                         try:
-                            results.append(json.loads(line))
+                            q.put(json.loads(line))
                         except json.JSONDecodeError:
                             job.unparsable += 1
         elif fmt == "csv":
             reader = csv.DictReader(io.StringIO(text))
             for row in reader:
-                results.append({k.strip(): v for k, v in row.items() if k})
-        return results
+                q.put({k.strip(): v for k, v in row.items() if k})
 
-    records = await loop.run_in_executor(None, _read)
-    for record in records:
+    async for record in _stream_from_executor(_produce):
         yield record
 
 
@@ -382,9 +406,7 @@ async def _s3_stream(uri: str, job) -> AsyncIterator[dict]:
     bucket = parts[0]
     key = parts[1] if len(parts) > 1 else ""
 
-    loop = asyncio.get_event_loop()
-
-    def _read():
+    def _produce(q):
         kwargs = {}
         if job.s3_key and job.s3_secret:
             kwargs["aws_access_key_id"] = job.s3_key
@@ -396,14 +418,13 @@ async def _s3_stream(uri: str, job) -> AsyncIterator[dict]:
         response = s3.get_object(Bucket=bucket, Key=key)
         body = response["Body"].read()
 
-        path = Path(key)
-        gz = is_gzipped(path, job)
-        fmt = detect_format(path, job)
+        s3_path = Path(key)
+        gz = is_gzipped(s3_path, job)
+        fmt = detect_format(s3_path, job)
 
         if gz:
             body = gzip.decompress(body)
 
-        results = []
         if fmt == "parquet":
             import pyarrow.parquet as pq
             from datetime import date, datetime as dt_cls
@@ -420,8 +441,8 @@ async def _s3_stream(uri: str, job) -> AsyncIterator[dict]:
                             record[k] = v.isoformat()
                         else:
                             record[k] = v
-                    results.append(record)
-            return results
+                    q.put(record)
+            return
 
         text = body.decode("utf-8")
 
@@ -430,28 +451,27 @@ async def _s3_stream(uri: str, job) -> AsyncIterator[dict]:
                 line = line.strip()
                 if line:
                     try:
-                        results.append(json.loads(line))
+                        q.put(json.loads(line))
                     except json.JSONDecodeError:
                         job.unparsable += 1
         elif fmt == "json":
             try:
                 data = json.loads(text)
-                results = data if isinstance(data, list) else [data]
+                items = data if isinstance(data, list) else [data]
+                for item in items:
+                    q.put(item)
             except json.JSONDecodeError:
-                # Fall back to JSONL
                 for line in text.strip().split("\n"):
                     line = line.strip()
                     if line:
                         try:
-                            results.append(json.loads(line))
+                            q.put(json.loads(line))
                         except json.JSONDecodeError:
                             job.unparsable += 1
         elif fmt == "csv":
             reader = csv.DictReader(io.StringIO(text))
             for row in reader:
-                results.append({k.strip(): v for k, v in row.items() if k})
-        return results
+                q.put({k.strip(): v for k, v in row.items() if k})
 
-    records = await loop.run_in_executor(None, _read)
-    for record in records:
+    async for record in _stream_from_executor(_produce):
         yield record

--- a/src/mixpanel_utils/streaming/io/parsers.py
+++ b/src/mixpanel_utils/streaming/io/parsers.py
@@ -116,7 +116,7 @@ async def resolve_input(data: Any, job) -> AsyncIterator[dict]:
 
     # Sync iterable (generator, etc.) but not string
     if hasattr(data, "__iter__") and not isinstance(data, (str, bytes)):
-        return _wrap_sync_iter(data)
+        return _iter_list(data)
 
     # String: file path, directory, glob, or cloud URL
     if isinstance(data, str):
@@ -143,12 +143,7 @@ async def resolve_input(data: Any, job) -> AsyncIterator[dict]:
     raise ValueError(f"Cannot determine data type for {type(data)}")
 
 
-async def _iter_list(data: list) -> AsyncIterator[dict]:
-    for item in data:
-        yield item
-
-
-async def _wrap_sync_iter(data) -> AsyncIterator[dict]:
+async def _iter_list(data) -> AsyncIterator[dict]:
     for item in data:
         yield item
 
@@ -321,9 +316,7 @@ async def _gcs_stream(uri: str, job) -> AsyncIterator[dict]:
     except ImportError:
         raise ImportError('Install gcsfs for GCS support: pip install "mixpanel-utils[streaming-gcs]"')
 
-    # Parse gs://bucket/path
     parts = uri.replace("gs://", "").split("/", 1)
-    bucket = parts[0]
     key = parts[1] if len(parts) > 1 else ""
 
     fs = gcsfs.GCSFileSystem(

--- a/src/mixpanel_utils/streaming/transforms/__init__.py
+++ b/src/mixpanel_utils/streaming/transforms/__init__.py
@@ -1,0 +1,1 @@
+"""Built-in transforms, deduplication, and filtering."""

--- a/src/mixpanel_utils/streaming/transforms/builtin.py
+++ b/src/mixpanel_utils/streaming/transforms/builtin.py
@@ -4,6 +4,8 @@ Each factory function returns a callable: (record: dict) -> dict | list | None
 Returning {} or None skips the record. Returning a list explodes into multiple records.
 """
 
+from __future__ import annotations
+
 import json
 import mmh3
 from dateutil import parser as dateparser

--- a/src/mixpanel_utils/streaming/transforms/builtin.py
+++ b/src/mixpanel_utils/streaming/transforms/builtin.py
@@ -1,0 +1,559 @@
+"""Built-in data transformation functions.
+
+Each factory function returns a callable: (record: dict) -> dict | list | None
+Returning {} or None skips the record. Returning a list explodes into multiple records.
+"""
+
+import json
+import mmh3
+from dateutil import parser as dateparser
+from datetime import datetime, timezone
+
+from ..constants import (
+    SPECIAL_PROPS, OUTSIDE_PROPS, VALID_OPERATIONS,
+    BAD_USER_IDS, MAX_STR_LEN, TIME_FIELD_ALIASES,
+)
+from ..utils import rename_keys
+
+
+def _noop(record):
+    return record
+
+
+def _truncate(s: str) -> str:
+    return s[:MAX_STR_LEN] if len(s) > MAX_STR_LEN else s
+
+
+def _is_not_empty(data) -> bool:
+    if data is None:
+        return False
+    if not isinstance(data, (dict, list)):
+        return False
+    if isinstance(data, list):
+        return len(data) > 0
+    return len(data) > 0
+
+
+def _parse_time(val) -> int | None:
+    """Try to parse a time value to unix epoch ms."""
+    if val is None:
+        return None
+    if isinstance(val, (int, float)):
+        return int(val)
+    if isinstance(val, str):
+        try:
+            return int(float(val))
+        except (ValueError, TypeError):
+            pass
+        try:
+            dt = dateparser.parse(val)
+            if dt:
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=timezone.utc)
+                return int(dt.timestamp() * 1000)
+        except (ValueError, TypeError):
+            pass
+    return None
+
+
+# ── ez_transforms ────────────────────────────────────────────────────
+
+def ez_transforms(job):
+    """Auto-fix records based on record type."""
+    rt = job.record_type
+
+    if rt.startswith("event") or rt == "export-import-event":
+        return _transform_event(job)
+    elif rt.startswith("user") or (rt == "export-import-profile" and not job.group_key):
+        return _transform_user(job)
+    elif rt.startswith("group") or (rt == "export-import-profile" and job.group_key):
+        return _transform_group(job)
+    return _noop
+
+
+def _transform_event(job):
+    def transform(record):
+        # 0. Use event_name as event if present
+        if not record.get("event") and isinstance(record.get("event_name"), str):
+            record["event"] = record.pop("event_name")
+
+        # 1. Ensure properties exists
+        if "properties" not in record or not isinstance(record.get("properties"), dict):
+            props = {k: v for k, v in record.items() if k not in ("properties", "event")}
+            record["properties"] = props
+            for k in props:
+                if k != "properties" and k != "event":
+                    del record[k]
+            record = {"event": record.get("event", ""), "properties": record.get("properties", {})}
+
+        # 1a. Use event_name from properties
+        if not record.get("event") and isinstance(record["properties"].get("event_name"), str):
+            record["event"] = record["properties"].pop("event_name")
+
+        props = record["properties"]
+
+        # 2a. Resolve time field aliases
+        if not props.get("time"):
+            for alias in TIME_FIELD_ALIASES:
+                if props.get(alias) is not None:
+                    props["time"] = props.pop(alias)
+                    break
+
+        # 2b. Normalize time to unix epoch
+        if props.get("time") is not None:
+            try:
+                num = float(props["time"])
+            except (ValueError, TypeError):
+                parsed = _parse_time(props["time"])
+                if parsed is not None:
+                    props["time"] = parsed
+
+        # 3. Add $insert_id if missing
+        if not props.get("$insert_id"):
+            try:
+                tuple_str = "-".join([
+                    str(record.get("event", "")),
+                    str(props.get("distinct_id", "")),
+                    str(props.get("time", "")),
+                ])
+                props["$insert_id"] = str(mmh3.hash(tuple_str, signed=False))
+            except Exception:
+                props["$insert_id"] = str(props.get("distinct_id", ""))
+
+        # 4. Rename well-known keys
+        for orig in ("user_id", "device_id", "source"):
+            if orig in props:
+                props[f"${orig}"] = props.pop(orig)
+
+        # 5. Promote special props
+        for key in list(props.keys()):
+            if key in SPECIAL_PROPS:
+                if key == "country":
+                    props["mp_country_code"] = props[key]
+                else:
+                    props[f"${key}"] = props[key]
+                del props[key]
+
+        # 6. Ensure IDs are strings
+        for k in ("distinct_id", "$user_id", "$device_id", "$insert_id"):
+            if props.get(k) is not None:
+                props[k] = str(props[k])
+
+        # 6a. Remove bad IDs
+        for k in ("distinct_id", "$user_id", "$device_id"):
+            if str(props.get(k, "")).lower() in BAD_USER_IDS or props.get(k) is None:
+                props.pop(k, None)
+
+        # 7. Truncate strings
+        for k, v in list(props.items()):
+            if isinstance(v, str):
+                props[k] = _truncate(v)
+
+        return record
+
+    return transform
+
+
+def _transform_user(job):
+    def transform(user):
+        directive = job.directive if job.directive in VALID_OPERATIONS else None
+
+        # Check if record already has complete vendor structure
+        has_operation = any(op in user for op in VALID_OPERATIONS)
+        has_distinct_id = "$distinct_id" in user or "distinct_id" in user
+        special_root_keys = {"$distinct_id", "distinct_id", "$token", "$ip",
+                             "$ignore_time", "$ignore_alias"} | set(VALID_OPERATIONS)
+        has_loose_props = any(k not in special_root_keys for k in user)
+        has_complete_vendor_structure = has_operation and has_distinct_id and not has_loose_props
+
+        if not has_complete_vendor_structure and (directive or not has_operation):
+            # Find distinct_id key
+            uuid_key = None
+            if "$distinct_id" in user:
+                uuid_key = "$distinct_id"
+            elif "distinct_id" in user:
+                uuid_key = "distinct_id"
+            if not uuid_key:
+                return {}
+
+            uuid_value = str(user[uuid_key])
+            base = dict(user)
+
+            if directive:
+                for op in VALID_OPERATIONS:
+                    if op in base and isinstance(base[op], dict):
+                        base.update(base[op])
+                        del base[op]
+
+            final_directive = directive or "$set"
+
+            if final_directive == "$unset":
+                props_to_unset = [
+                    k for k in base
+                    if k != uuid_key and k != "$token" and not k.startswith("$")
+                ]
+                user = {final_directive: props_to_unset}
+            else:
+                user = {final_directive: base}
+                user[final_directive].pop(uuid_key, None)
+                user[final_directive].pop("$token", None)
+
+                # Handle Mixpanel-export shape
+                if isinstance(user[final_directive].get("$properties"), dict):
+                    user[final_directive] = dict(user[final_directive]["$properties"])
+
+            user["$distinct_id"] = uuid_value
+
+        # Ensure $token
+        if not user.get("$token") and job.token:
+            user["$token"] = job.token
+
+        # Rename special props inside operation buckets
+        for op in VALID_OPERATIONS:
+            if isinstance(user.get(op), dict):
+                for prop in list(user[op].keys()):
+                    if prop in SPECIAL_PROPS:
+                        if prop in ("country", "country_code"):
+                            user[op]["$country_code"] = str(user[op][prop]).upper()
+                        else:
+                            user[op][f"${prop}"] = user[op][prop]
+                        del user[op][prop]
+
+        # Extract outside props from operation buckets
+        for op in VALID_OPERATIONS:
+            if isinstance(user.get(op), dict):
+                for prop in OUTSIDE_PROPS:
+                    if prop in user[op]:
+                        user[f"${prop}"] = user[op].pop(prop)
+
+        # Pull remaining outside props to root & truncate
+        for key, val in list(user.items()):
+            if key in OUTSIDE_PROPS:
+                user[f"${key}"] = val
+                del user[key]
+            elif isinstance(val, str):
+                user[key] = _truncate(val)
+
+        return user
+
+    return transform
+
+
+def _transform_group(job):
+    def transform(group):
+        directive = job.directive if job.directive in VALID_OPERATIONS else None
+
+        # Skip reshape if record already has valid group structure
+        has_group_key = "$group_key" in group
+        has_group_id = "$group_id" in group
+        has_operation = any(op in group for op in VALID_OPERATIONS)
+        if has_group_key and has_group_id and has_operation:
+            if not group.get("$token") and job.token:
+                group["$token"] = job.token
+            return group
+
+        if directive or not has_operation:
+            # Fallback chain for uuid
+            uuid_key = None
+            for candidate_key in [job.group_key, "$group_id", "group_id", "$distinct_id", "distinct_id"]:
+                if candidate_key and group.get(candidate_key):
+                    uuid_key = candidate_key
+                    break
+            if not uuid_key:
+                return {}
+
+            uuid_value = str(group[uuid_key])
+            base = dict(group)
+
+            if directive:
+                for op in VALID_OPERATIONS:
+                    if op in base and isinstance(base[op], dict):
+                        base.update(base[op])
+                        del base[op]
+
+            final_directive = directive or "$set"
+
+            if final_directive == "$unset":
+                props_to_unset = [
+                    k for k in base
+                    if k not in (uuid_key, "$group_id", "$token", "$group_key") and not k.startswith("$")
+                ]
+                group = {final_directive: props_to_unset}
+            else:
+                group = {final_directive: base}
+                group[final_directive].pop(uuid_key, None)
+                group[final_directive].pop("$group_id", None)
+                group[final_directive].pop("$token", None)
+
+            group["$group_id"] = uuid_value
+
+        # Ensure $token and $group_key
+        if not group.get("$token") and job.token:
+            group["$token"] = job.token
+        if not group.get("$group_key") and job.group_key:
+            group["$group_key"] = job.group_key
+
+        # Rename special props
+        for op in VALID_OPERATIONS:
+            if isinstance(group.get(op), dict):
+                for prop in list(group[op].keys()):
+                    if prop in SPECIAL_PROPS:
+                        group[op][f"${prop}"] = group[op][prop]
+                        del group[op][prop]
+
+        # Extract outside props
+        for op in VALID_OPERATIONS:
+            if isinstance(group.get(op), dict):
+                for prop in OUTSIDE_PROPS:
+                    if prop in group[op]:
+                        group[f"${prop}"] = group[op].pop(prop)
+
+        # Pull remaining outside props to root & truncate
+        for key, val in list(group.items()):
+            if key in OUTSIDE_PROPS:
+                group[f"${key}"] = val
+                del group[key]
+            elif isinstance(val, str):
+                group[key] = _truncate(val)
+
+        return group
+
+    return transform
+
+
+# ── Other Transforms ─────────────────────────────────────────────────
+
+def apply_aliases(job):
+    """Rename property keys based on aliases mapping."""
+    aliases = job.aliases or {}
+    rt = job.record_type
+
+    def transform(record):
+        if not aliases:
+            return record
+        if rt == "event":
+            if record.get("properties"):
+                record["properties"] = rename_keys(record["properties"], aliases)
+            else:
+                record = rename_keys(record, aliases)
+        else:
+            op = next((k for k in record if k in VALID_OPERATIONS), None)
+            if op and isinstance(record[op], dict):
+                record[op] = rename_keys(record[op], aliases)
+            else:
+                record = rename_keys(record, aliases)
+        return record
+
+    return transform
+
+
+def add_tags(job):
+    """Merge tags into every record."""
+    tags = job.tags or {}
+    rt = job.record_type
+
+    def transform(record):
+        if not tags:
+            return record
+        if rt == "event":
+            if record.get("properties"):
+                record["properties"] = {**record["properties"], **tags}
+        elif rt in ("user", "group"):
+            op = next((k for k in record if k in VALID_OPERATIONS), None)
+            if op and isinstance(record[op], dict):
+                record[op] = {**record[op], **tags}
+        return record
+
+    return transform
+
+
+def add_token(job):
+    """Add Mixpanel token to every record."""
+    token = job.token
+    rt = job.record_type
+
+    def transform(record):
+        if rt == "event":
+            if record.get("properties"):
+                record["properties"]["token"] = token
+            else:
+                record["properties"] = {"token": token}
+        elif rt in ("user", "group"):
+            record["$token"] = token
+        return record
+
+    return transform
+
+
+def remove_nulls(values_to_remove=None):
+    """Remove null/empty values from records."""
+    if values_to_remove is None:
+        values_to_remove = [None, ""]
+
+    def transform(record):
+        keys_to_check = ["properties"] + VALID_OPERATIONS
+        for record_key in keys_to_check:
+            bucket = record.get(record_key)
+            if isinstance(bucket, dict):
+                for k in list(bucket.keys()):
+                    if bucket[k] in values_to_remove:
+                        del bucket[k]
+                    elif isinstance(bucket[k], dict) and len(bucket[k]) == 0:
+                        del bucket[k]
+        return record
+
+    return transform
+
+
+def flatten_properties(sep="."):
+    """Flatten nested objects in properties."""
+    def _flatten(obj, roots=None):
+        if roots is None:
+            roots = []
+        result = {}
+        for key, val in obj.items():
+            if isinstance(val, dict) and not isinstance(val, list):
+                result.update(_flatten(val, roots + [key]))
+            else:
+                result[sep.join(roots + [key])] = val
+        return result
+
+    def transform(record):
+        if record.get("properties") and isinstance(record["properties"], dict):
+            record["properties"] = _flatten(record["properties"])
+            return record
+        if record.get("$set") and isinstance(record["$set"], dict):
+            record["$set"] = _flatten(record["$set"])
+            return record
+        return record
+
+    return transform
+
+
+def utc_offset(hours=0):
+    """Offset event timestamps by N hours."""
+    offset_ms = hours * 3600 * 1000
+
+    def transform(record):
+        if record.get("properties", {}).get("time") is not None:
+            try:
+                t = int(record["properties"]["time"])
+                # If seconds, convert to ms
+                if len(str(abs(t))) <= 10:
+                    t *= 1000
+                record["properties"]["time"] = t + offset_ms
+            except (ValueError, TypeError):
+                pass
+        return record
+
+    return transform
+
+
+def fix_time():
+    """Normalize timestamps to unix epoch ms."""
+    def transform(record):
+        if not record.get("properties"):
+            return record
+        if record["properties"].get("time") is not None:
+            try:
+                float(record["properties"]["time"])
+            except (ValueError, TypeError):
+                parsed = _parse_time(record["properties"]["time"])
+                if parsed is not None:
+                    record["properties"]["time"] = parsed
+        else:
+            record["properties"]["time"] = int(datetime.now(timezone.utc).timestamp() * 1000)
+        return record
+
+    return transform
+
+
+def fix_json():
+    """Try to parse string values that look like JSON."""
+    def _might_be_json(val):
+        if not isinstance(val, str):
+            return False
+        s = val.strip()
+        return (s.startswith("{") and s.endswith("}")) or (s.startswith("[") and s.endswith("]"))
+
+    def transform(record):
+        if record.get("properties"):
+            for key in list(record["properties"].keys()):
+                val = record["properties"][key]
+                if _might_be_json(val):
+                    try:
+                        record["properties"][key] = json.loads(val)
+                    except json.JSONDecodeError:
+                        pass
+        return record
+
+    return transform
+
+
+def scrub_properties(props_to_scrub):
+    """Remove specified properties from records."""
+    def transform(record):
+        if record.get("properties"):
+            for prop in props_to_scrub:
+                record["properties"].pop(prop, None)
+        for op in VALID_OPERATIONS:
+            if isinstance(record.get(op), dict):
+                for prop in props_to_scrub:
+                    record[op].pop(prop, None)
+        return record
+
+    return transform
+
+
+def drop_columns(columns):
+    """Drop specified top-level columns from records."""
+    def transform(record):
+        for col in columns:
+            record.pop(col, None)
+        return record
+
+    return transform
+
+
+def set_distinct_id_from_v2_props():
+    """Set distinct_id from $user_id or $device_id for v2 compatibility."""
+    def transform(record):
+        if record.get("properties"):
+            if not record["properties"].get("distinct_id"):
+                if record["properties"].get("$user_id"):
+                    record["properties"]["distinct_id"] = record["properties"]["$user_id"]
+                elif record["properties"].get("$device_id"):
+                    record["properties"]["distinct_id"] = record["properties"]["$device_id"]
+        return record
+
+    return transform
+
+
+def add_insert(insert_tuple):
+    """Add $insert_id based on a tuple of keys or hash the whole record."""
+    def transform(record):
+        if not record:
+            return {}
+        if not insert_tuple:
+            return record
+        if record.get("properties", {}).get("$insert_id"):
+            return record
+
+        actual_tuple = []
+        for key in insert_tuple:
+            if record.get(key):
+                actual_tuple.append(str(record[key]))
+            elif record.get("properties", {}).get(key):
+                actual_tuple.append(str(record["properties"][key]))
+
+        if len(actual_tuple) == len(insert_tuple):
+            insert_id = str(mmh3.hash("-".join(actual_tuple), signed=False))
+        else:
+            insert_id = str(mmh3.hash(json.dumps(record, sort_keys=True), signed=False))
+
+        if "properties" not in record:
+            record["properties"] = {}
+        record["properties"]["$insert_id"] = insert_id
+        return record
+
+    return transform

--- a/src/mixpanel_utils/streaming/transforms/builtin.py
+++ b/src/mixpanel_utils/streaming/transforms/builtin.py
@@ -387,7 +387,6 @@ def add_token(job):
 
 
 def remove_nulls(values_to_remove=None):
-    """Remove null/empty values from records."""
     if values_to_remove is None:
         values_to_remove = [None, ""]
 
@@ -407,7 +406,6 @@ def remove_nulls(values_to_remove=None):
 
 
 def flatten_properties(sep="."):
-    """Flatten nested objects in properties."""
     def _flatten(obj, roots=None):
         if roots is None:
             roots = []
@@ -432,7 +430,6 @@ def flatten_properties(sep="."):
 
 
 def utc_offset(hours=0):
-    """Offset event timestamps by N hours."""
     offset_ms = hours * 3600 * 1000
 
     def transform(record):
@@ -451,7 +448,6 @@ def utc_offset(hours=0):
 
 
 def fix_time():
-    """Normalize timestamps to unix epoch ms."""
     def transform(record):
         if not record.get("properties"):
             return record
@@ -470,7 +466,6 @@ def fix_time():
 
 
 def fix_json():
-    """Try to parse string values that look like JSON."""
     def _might_be_json(val):
         if not isinstance(val, str):
             return False

--- a/src/mixpanel_utils/streaming/transforms/builtin.py
+++ b/src/mixpanel_utils/streaming/transforms/builtin.py
@@ -71,11 +71,7 @@ def _transform_event(job):
         # 1. Ensure properties exists
         if "properties" not in record or not isinstance(record.get("properties"), dict):
             props = {k: v for k, v in record.items() if k not in ("properties", "event")}
-            record["properties"] = props
-            for k in props:
-                if k != "properties" and k != "event":
-                    del record[k]
-            record = {"event": record.get("event", ""), "properties": record.get("properties", {})}
+            record = {"event": record.get("event", ""), "properties": props}
 
         # 1a. Use event_name from properties
         if not record.get("event") and isinstance(record["properties"].get("event_name"), str):
@@ -411,7 +407,7 @@ def flatten_properties(sep="."):
             roots = []
         result = {}
         for key, val in obj.items():
-            if isinstance(val, dict) and not isinstance(val, list):
+            if isinstance(val, dict):
                 result.update(_flatten(val, roots + [key]))
             else:
                 result[sep.join(roots + [key])] = val

--- a/src/mixpanel_utils/streaming/transforms/builtin.py
+++ b/src/mixpanel_utils/streaming/transforms/builtin.py
@@ -146,6 +146,15 @@ def _transform_event(job):
             if str(props.get(k, "")).lower() in BAD_USER_IDS or props.get(k) is None:
                 props.pop(k, None)
 
+        # 6b. Fallback distinct_id from $user_id or $device_id
+        if not props.get("distinct_id"):
+            if props.get("$user_id"):
+                props["distinct_id"] = props["$user_id"]
+            elif props.get("$device_id"):
+                props["distinct_id"] = props["$device_id"]
+            else:
+                props["distinct_id"] = ""
+
         # 7. Truncate strings
         for k, v in list(props.items()):
             if isinstance(v, str):

--- a/src/mixpanel_utils/streaming/transforms/builtin.py
+++ b/src/mixpanel_utils/streaming/transforms/builtin.py
@@ -7,8 +7,6 @@ Returning {} or None skips the record. Returning a list explodes into multiple r
 from __future__ import annotations
 
 import json
-import mmh3
-from dateutil import parser as dateparser
 from datetime import datetime, timezone
 
 from ..constants import (
@@ -48,6 +46,7 @@ def _parse_time(val) -> int | None:
         except (ValueError, TypeError):
             pass
         try:
+            from dateutil import parser as dateparser
             dt = dateparser.parse(val)
             if dt:
                 if dt.tzinfo is None:
@@ -113,6 +112,7 @@ def _transform_event(job):
         # 3. Add $insert_id if missing
         if not props.get("$insert_id"):
             try:
+                import mmh3
                 tuple_str = "-".join([
                     str(record.get("event", "")),
                     str(props.get("distinct_id", "")),
@@ -534,6 +534,8 @@ def set_distinct_id_from_v2_props():
 def add_insert(insert_tuple):
     """Add $insert_id based on a tuple of keys or hash the whole record."""
     def transform(record):
+        import mmh3
+
         if not record:
             return {}
         if not insert_tuple:

--- a/src/mixpanel_utils/streaming/transforms/builtin.py
+++ b/src/mixpanel_utils/streaming/transforms/builtin.py
@@ -24,16 +24,6 @@ def _truncate(s: str) -> str:
     return s[:MAX_STR_LEN] if len(s) > MAX_STR_LEN else s
 
 
-def _is_not_empty(data) -> bool:
-    if data is None:
-        return False
-    if not isinstance(data, (dict, list)):
-        return False
-    if isinstance(data, list):
-        return len(data) > 0
-    return len(data) > 0
-
-
 def _parse_time(val) -> int | None:
     """Try to parse a time value to unix epoch ms."""
     if val is None:

--- a/src/mixpanel_utils/streaming/transforms/dedup.py
+++ b/src/mixpanel_utils/streaming/transforms/dedup.py
@@ -1,0 +1,23 @@
+"""Content-based deduplication using MurmurHash."""
+
+import json
+import mmh3
+
+
+def dedupe_records(job):
+    """Return a transform that skips duplicate records based on content hash.
+
+    Uses MurmurHash v3 on stable JSON stringification. Records with the same
+    hash are filtered out (return {}).
+    """
+    hash_table = job.hash_table  # set()
+
+    def transform(record):
+        h = mmh3.hash(json.dumps(record, sort_keys=True), signed=False)
+        if h in hash_table:
+            job.duplicates += 1
+            return {}
+        hash_table.add(h)
+        return record
+
+    return transform

--- a/src/mixpanel_utils/streaming/transforms/dedup.py
+++ b/src/mixpanel_utils/streaming/transforms/dedup.py
@@ -1,7 +1,6 @@
 """Content-based deduplication using MurmurHash."""
 
 import json
-import mmh3
 
 
 def dedupe_records(job):
@@ -13,6 +12,7 @@ def dedupe_records(job):
     hash_table = job.hash_table  # set()
 
     def transform(record):
+        import mmh3
         h = mmh3.hash(json.dumps(record, sort_keys=True), signed=False)
         if h in hash_table:
             job.duplicates += 1

--- a/src/mixpanel_utils/streaming/transforms/filters.py
+++ b/src/mixpanel_utils/streaming/transforms/filters.py
@@ -1,6 +1,5 @@
 """Whitelist/blacklist and epoch-based filtering transforms."""
 
-from datetime import datetime, timezone
 
 
 def whitelist_blacklist(job, params):

--- a/src/mixpanel_utils/streaming/transforms/filters.py
+++ b/src/mixpanel_utils/streaming/transforms/filters.py
@@ -1,0 +1,117 @@
+"""Whitelist/blacklist and epoch-based filtering transforms."""
+
+from datetime import datetime, timezone
+
+
+def whitelist_blacklist(job, params):
+    """Filter records by event name, property keys, property values, and combos."""
+    event_wl = params.get("event_whitelist", [])
+    event_bl = params.get("event_blacklist", [])
+    pk_wl = params.get("prop_key_whitelist", [])
+    pk_bl = params.get("prop_key_blacklist", [])
+    pv_wl = params.get("prop_val_whitelist", [])
+    pv_bl = params.get("prop_val_blacklist", [])
+    combo_wl = params.get("combo_white_list", {})
+    combo_bl = params.get("combo_black_list", {})
+
+    def transform(record):
+        # Event whitelist
+        if event_wl:
+            if record.get("event") not in event_wl:
+                job.whitelist_skipped += 1
+                return {}
+
+        # Event blacklist
+        if event_bl:
+            if record.get("event") in event_bl:
+                job.blacklist_skipped += 1
+                return {}
+
+        props = record.get("properties", {})
+
+        # Prop key whitelist
+        if pk_wl:
+            if not any(k in pk_wl for k in props):
+                job.whitelist_skipped += 1
+                return {}
+
+        # Prop key blacklist
+        if pk_bl:
+            if any(k in pk_bl for k in props):
+                job.blacklist_skipped += 1
+                return {}
+
+        # Prop val whitelist
+        if pv_wl:
+            if not any(v in pv_wl for v in props.values()):
+                job.whitelist_skipped += 1
+                return {}
+
+        # Prop val blacklist
+        if pv_bl:
+            if any(v in pv_bl for v in props.values()):
+                job.blacklist_skipped += 1
+                return {}
+
+        # Combo whitelist
+        if combo_wl:
+            found = False
+            for key, vals in combo_wl.items():
+                if not isinstance(vals, list):
+                    vals = [vals]
+                prop_val = props.get(key)
+                if prop_val is not None and str(prop_val) in [str(v) for v in vals]:
+                    found = True
+                    break
+            if not found:
+                job.whitelist_skipped += 1
+                return {}
+
+        # Combo blacklist
+        if combo_bl:
+            for key, vals in combo_bl.items():
+                if not isinstance(vals, list):
+                    vals = [vals]
+                prop_val = props.get(key)
+                if prop_val is not None and str(prop_val) in [str(v) for v in vals]:
+                    job.blacklist_skipped += 1
+                    return {}
+
+        return record
+
+    return transform
+
+
+def epoch_filter(job):
+    """Filter events by time range (epoch_start..epoch_end)."""
+    epoch_start = job.epoch_start
+    epoch_end = job.epoch_end
+
+    def transform(record):
+        if job.record_type != "event":
+            return record
+
+        props = record.get("properties", {})
+        event_time = props.get("time")
+        if event_time is None:
+            return record
+
+        try:
+            t = int(event_time)
+        except (ValueError, TypeError):
+            return record
+
+        # Normalize to seconds
+        if len(str(abs(t))) > 10:
+            t = t // 1000
+
+        if t < epoch_start:
+            job.out_of_bounds += 1
+            return None
+        if t > epoch_end:
+            job.out_of_bounds += 1
+            return None
+
+        return record
+
+    return transform

--- a/src/mixpanel_utils/streaming/types.py
+++ b/src/mixpanel_utils/streaming/types.py
@@ -1,42 +1,16 @@
-"""Type definitions for the streaming pipeline."""
+"""Type definitions for the streaming pipeline.
+
+These TypedDicts provide intellisense/autocomplete for the creds and options
+dicts accepted by mp_import(), MpStream, and StreamInterface methods.
+"""
 
 from __future__ import annotations
 
-from enum import Enum
-from typing import TypedDict, Any, Callable, Optional
-
-
-class RecordType(str, Enum):
-    EVENT = "event"
-    USER = "user"
-    GROUP = "group"
-    EXPORT = "export"
-    PROFILE_EXPORT = "profile-export"
-    PROFILE_DELETE = "profile-delete"
-    GROUP_EXPORT = "group-export"
-    GROUP_DELETE = "group-delete"
-    EXPORT_IMPORT_EVENT = "export-import-event"
-    EXPORT_IMPORT_PROFILE = "export-import-profile"
-    EXPORT_IMPORT_GROUP = "export-import-group"
-
-
-class Region(str, Enum):
-    US = "US"
-    EU = "EU"
-    IN = "IN"
-
-
-class Vendor(str, Enum):
-    AMPLITUDE = "amplitude"
-    HEAP = "heap"
-    GA4 = "ga4"
-    POSTHOG = "posthog"
-    MPARTICLE = "mparticle"
-    JUNE = "june"
-    MIXPANEL = "mixpanel"
+from typing import TypedDict, Callable
 
 
 class Creds(TypedDict, total=False):
+    """Mixpanel authentication credentials."""
     acct: str
     pass_: str
     project: int | str
@@ -44,57 +18,59 @@ class Creds(TypedDict, total=False):
     secret: str
     bearer: str
     group_key: str
+    data_group_id: str
     workspace: int | str
     org: int | str
     second_token: str
+    # Cloud storage (can also go in Options)
     gcp_project_id: str
     gcs_credentials: str
     s3_key: str
     s3_secret: str
     s3_region: str
-    data_group_id: str
 
 
 class Options(TypedDict, total=False):
+    """Import/export configuration options."""
     # Core
-    record_type: str
-    region: str
-    stream_format: str
+    record_type: str  # event, user, group, export, profile-export, profile-delete, group-export, group-delete, export-import-event, export-import-profile, export-import-group
+    region: str  # US, EU, IN
+    vendor: str  # amplitude, heap, ga4, posthog, mparticle, june, mixpanel
+    vendor_opts: dict
+    stream_format: str  # jsonl, json, csv, parquet
 
     # Performance
     workers: int
-    concurrency: int
     records_per_batch: int
     bytes_per_batch: int
     max_retries: int
-    high_water: int
-
-    # Compression
     compress: bool
     compression_level: int
-    is_gzip: bool
 
-    # Transforms
+    # Data transforms
     transform_func: Callable
     fix_data: bool
     fix_time: bool
+    fix_json: bool
     remove_nulls: bool
+    flatten: bool
+    add_token: bool
     time_offset: int
     tags: dict
     aliases: dict
-    flatten: bool
-    fix_json: bool
-    add_token: bool
-    directive: str
-
-    # Vendor
-    vendor: str
-    vendor_opts: dict
+    directive: str  # $set, $set_once, $add, $union, $append, $remove, $unset
+    dimension_maps: list
+    insert_id_tuple: list[str]
+    drop_columns: list[str]
+    scrub_props: list[str]
+    v2_compat: bool
+    create_profiles: bool
 
     # Filtering
     dedupe: bool
     epoch_start: int
     epoch_end: int
+    max_records: int | None
     event_whitelist: list[str]
     event_blacklist: list[str]
     prop_key_whitelist: list[str]
@@ -103,10 +79,6 @@ class Options(TypedDict, total=False):
     prop_val_blacklist: list[str]
     combo_white_list: dict[str, list[str]]
     combo_black_list: dict[str, list[str]]
-    scrub_props: list[str]
-
-    # Validation
-    strict: bool
 
     # Export
     start: str
@@ -114,25 +86,36 @@ class Options(TypedDict, total=False):
     where: str
     limit: int
     cohort_id: int
+    params: dict
 
     # Output
+    strict: bool
     verbose: bool
     dry_run: bool
     write_to_file: bool
     logs: bool
     abridged: bool
+    is_gzip: bool
+    output_file_path: str
+    progress_callback: Callable
 
-    # Insert ID
-    insert_id_tuple: list[str]
+    # Cloud storage (can also go in Creds)
+    gcp_project_id: str
+    gcs_credentials: str
+    s3_key: str
+    s3_secret: str
+    s3_region: str
 
-    # Max records
-    max_records: int | None
+    # Group analytics
+    group_key: str
+    data_group_id: str
 
-    # Heavy objects (dimension maps, etc.)
+    # Advanced
     heavy_objects: dict
 
 
 class ImportResults(TypedDict, total=False):
+    """Results returned by mp_import() and streaming methods."""
     record_type: str
     total: int
     success: int
@@ -163,4 +146,3 @@ class ImportResults(TypedDict, total=False):
     dry_run: list
     vendor: str
     vendor_opts: dict
-    files: list[str]

--- a/src/mixpanel_utils/streaming/types.py
+++ b/src/mixpanel_utils/streaming/types.py
@@ -1,0 +1,164 @@
+"""Type definitions for the streaming pipeline."""
+
+from enum import Enum
+from typing import TypedDict, Any, Callable, Optional
+
+
+class RecordType(str, Enum):
+    EVENT = "event"
+    USER = "user"
+    GROUP = "group"
+    EXPORT = "export"
+    PROFILE_EXPORT = "profile-export"
+    PROFILE_DELETE = "profile-delete"
+    GROUP_EXPORT = "group-export"
+    GROUP_DELETE = "group-delete"
+    EXPORT_IMPORT_EVENT = "export-import-event"
+    EXPORT_IMPORT_PROFILE = "export-import-profile"
+    EXPORT_IMPORT_GROUP = "export-import-group"
+
+
+class Region(str, Enum):
+    US = "US"
+    EU = "EU"
+    IN = "IN"
+
+
+class Vendor(str, Enum):
+    AMPLITUDE = "amplitude"
+    HEAP = "heap"
+    GA4 = "ga4"
+    POSTHOG = "posthog"
+    MPARTICLE = "mparticle"
+    JUNE = "june"
+    MIXPANEL = "mixpanel"
+
+
+class Creds(TypedDict, total=False):
+    acct: str
+    pass_: str
+    project: int | str
+    token: str
+    secret: str
+    bearer: str
+    group_key: str
+    workspace: int | str
+    org: int | str
+    second_token: str
+    gcp_project_id: str
+    gcs_credentials: str
+    s3_key: str
+    s3_secret: str
+    s3_region: str
+    data_group_id: str
+
+
+class Options(TypedDict, total=False):
+    # Core
+    record_type: str
+    region: str
+    stream_format: str
+
+    # Performance
+    workers: int
+    concurrency: int
+    records_per_batch: int
+    bytes_per_batch: int
+    max_retries: int
+    high_water: int
+
+    # Compression
+    compress: bool
+    compression_level: int
+    is_gzip: bool
+
+    # Transforms
+    transform_func: Callable
+    fix_data: bool
+    fix_time: bool
+    remove_nulls: bool
+    time_offset: int
+    tags: dict
+    aliases: dict
+    flatten: bool
+    fix_json: bool
+    add_token: bool
+    directive: str
+
+    # Vendor
+    vendor: str
+    vendor_opts: dict
+
+    # Filtering
+    dedupe: bool
+    epoch_start: int
+    epoch_end: int
+    event_whitelist: list[str]
+    event_blacklist: list[str]
+    prop_key_whitelist: list[str]
+    prop_key_blacklist: list[str]
+    prop_val_whitelist: list[str]
+    prop_val_blacklist: list[str]
+    combo_white_list: dict[str, list[str]]
+    combo_black_list: dict[str, list[str]]
+    scrub_props: list[str]
+
+    # Validation
+    strict: bool
+
+    # Export
+    start: str
+    end: str
+    where: str
+    limit: int
+    cohort_id: int
+
+    # Output
+    verbose: bool
+    dry_run: bool
+    write_to_file: bool
+    logs: bool
+    abridged: bool
+
+    # Insert ID
+    insert_id_tuple: list[str]
+
+    # Max records
+    max_records: int | None
+
+    # Heavy objects (dimension maps, etc.)
+    heavy_objects: dict
+
+
+class ImportResults(TypedDict, total=False):
+    record_type: str
+    total: int
+    success: int
+    failed: int
+    empty: int
+    out_of_bounds: int
+    duplicates: int
+    whitelist_skipped: int
+    blacklist_skipped: int
+    unparsable: int
+    start_time: str
+    end_time: str
+    duration: int
+    duration_human: str
+    bytes: int
+    bytes_human: str
+    requests: int
+    batches: int
+    retries: int
+    rate_limit: int
+    server_errors: int
+    client_errors: int
+    eps: float
+    rps: float
+    mbps: float
+    errors: dict[str, int]
+    responses: list
+    dry_run: list
+    vendor: str
+    vendor_opts: dict
+    files: list[str]

--- a/src/mixpanel_utils/streaming/types.py
+++ b/src/mixpanel_utils/streaming/types.py
@@ -1,5 +1,7 @@
 """Type definitions for the streaming pipeline."""
 
+from __future__ import annotations
+
 from enum import Enum
 from typing import TypedDict, Any, Callable, Optional
 

--- a/src/mixpanel_utils/streaming/utils.py
+++ b/src/mixpanel_utils/streaming/utils.py
@@ -1,5 +1,7 @@
 """Utility helpers for mixpanel_import."""
 
+from __future__ import annotations
+
 import time
 from datetime import datetime
 

--- a/src/mixpanel_utils/streaming/utils.py
+++ b/src/mixpanel_utils/streaming/utils.py
@@ -1,0 +1,82 @@
+"""Utility helpers for mixpanel_import."""
+
+import time
+from datetime import datetime
+
+
+def bytes_human(b: int | float) -> str:
+    """Convert bytes to human-readable string."""
+    for unit in ["B", "KB", "MB", "GB", "TB"]:
+        if abs(b) < 1024:
+            return f"{b:.1f} {unit}"
+        b /= 1024
+    return f"{b:.1f} PB"
+
+
+def comma(n: int | float) -> str:
+    """Format number with commas."""
+    return f"{n:,.0f}"
+
+
+def rename_keys(obj: dict, aliases: dict) -> dict:
+    """Rename keys in a dict according to aliases mapping."""
+    if not aliases:
+        return obj
+    result = {}
+    for k, v in obj.items():
+        new_key = aliases.get(k, k)
+        result[new_key] = v
+    return result
+
+
+class Timer:
+    """Simple timer for tracking job duration."""
+
+    def __init__(self):
+        self.start_time: float | None = None
+        self.end_time: float | None = None
+
+    def start(self) -> "Timer":
+        self.start_time = time.time()
+        self.end_time = None
+        return self
+
+    def stop(self) -> "Timer":
+        self.end_time = time.time()
+        return self
+
+    def elapsed(self) -> float:
+        """Return elapsed seconds since start."""
+        end = self.end_time or time.time()
+        start = self.start_time or end
+        return end - start
+
+    @property
+    def delta_ms(self) -> int:
+        end = self.end_time or time.time()
+        start = self.start_time or end
+        return int((end - start) * 1000)
+
+    @property
+    def human(self) -> str:
+        delta = self.delta_ms
+        if delta < 1000:
+            return f"{delta}ms"
+        elif delta < 60000:
+            return f"{delta / 1000:.1f}s"
+        elif delta < 3600000:
+            minutes = delta // 60000
+            seconds = (delta % 60000) // 1000
+            return f"{minutes}m {seconds}s"
+        else:
+            hours = delta // 3600000
+            minutes = (delta % 3600000) // 60000
+            return f"{hours}h {minutes}m"
+
+    def report(self) -> dict:
+        return {
+            "delta": self.delta_ms,
+            "human": self.human,
+            "start_time": datetime.fromtimestamp(self.start_time).isoformat() if self.start_time else None,
+            "end_time": datetime.fromtimestamp(self.end_time).isoformat() if self.end_time else None,
+        }

--- a/src/mixpanel_utils/streaming/vendors/__init__.py
+++ b/src/mixpanel_utils/streaming/vendors/__init__.py
@@ -1,0 +1,1 @@
+"""Vendor-specific data transforms (Amplitude, Heap, GA4, PostHog, mParticle, June, Mixpanel)."""

--- a/src/mixpanel_utils/streaming/vendors/amplitude.py
+++ b/src/mixpanel_utils/streaming/vendors/amplitude.py
@@ -8,7 +8,6 @@ from datetime import timezone
 AMP_MIX_PAIRS = [
     ("app_version", "$app_version_string"),
     ("os_name", "$os"),
-    ("os_name", "$browser"),
     ("os_version", "$os_version"),
     ("device_brand", "$brand"),
     ("device_manufacturer", "$manufacturer"),
@@ -76,7 +75,7 @@ def amp_events_to_mp(options: dict):
                 str(event_time),
                 str(event_name),
             ])
-            mp_event["properties"]["$insert_id"] = str(mmh3.hash(tuple_str) & 0xFFFFFFFF)
+            mp_event["properties"]["$insert_id"] = str(mmh3.hash(tuple_str, signed=False))
 
         # Canonical ID resolution
         user_props = amp_event.get("user_properties", {}) or {}

--- a/src/mixpanel_utils/streaming/vendors/amplitude.py
+++ b/src/mixpanel_utils/streaming/vendors/amplitude.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import mmh3
-from dateutil import parser as dateparser
 from datetime import timezone
 
 # Amplitude → Mixpanel default property mappings
@@ -35,6 +33,9 @@ def amp_events_to_mp(options: dict):
     include_experiment_props = options.get("includeExperimentProps", False)
 
     def transform(amp_event: dict) -> dict | None:
+        import mmh3
+        from dateutil import parser as dateparser
+
         event_name = amp_event.get("event_type", "")
 
         # Skip experiment events

--- a/src/mixpanel_utils/streaming/vendors/amplitude.py
+++ b/src/mixpanel_utils/streaming/vendors/amplitude.py
@@ -1,5 +1,7 @@
 """Amplitude to Mixpanel vendor transforms."""
 
+from __future__ import annotations
+
 import mmh3
 from dateutil import parser as dateparser
 from datetime import timezone

--- a/src/mixpanel_utils/streaming/vendors/amplitude.py
+++ b/src/mixpanel_utils/streaming/vendors/amplitude.py
@@ -1,0 +1,185 @@
+"""Amplitude to Mixpanel vendor transforms."""
+
+import mmh3
+from dateutil import parser as dateparser
+from datetime import timezone
+
+# Amplitude → Mixpanel default property mappings
+AMP_MIX_PAIRS = [
+    ("app_version", "$app_version_string"),
+    ("os_name", "$os"),
+    ("os_name", "$browser"),
+    ("os_version", "$os_version"),
+    ("device_brand", "$brand"),
+    ("device_manufacturer", "$manufacturer"),
+    ("device_model", "$model"),
+    ("region", "$region"),
+    ("city", "$city"),
+]
+
+# Keys to remove from amp event after extraction
+_AMP_REMOVE_KEYS = {
+    "device_id", "event_time", "$insert_id", "user_properties",
+    "group_properties", "global_user_properties", "event_properties",
+    "groups", "data",
+}
+
+
+def amp_events_to_mp(options: dict):
+    """Factory: returns transform for Amplitude events → Mixpanel events."""
+    user_id_key = options.get("user_id", "user_id")
+    v2_compat = options.get("v2_compat", True)
+    include_experiment_events = options.get("includeExperimentEvents", False)
+    include_experiment_props = options.get("includeExperimentProps", False)
+
+    def transform(amp_event: dict) -> dict | None:
+        event_name = amp_event.get("event_type", "")
+
+        # Skip experiment events
+        if not include_experiment_events:
+            if event_name and "[experiment]" in event_name.lower():
+                return None
+
+        # Parse time
+        event_time = amp_event.get("event_time", "")
+        try:
+            ts = dateparser.parse(event_time)
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+            time_ms = int(ts.timestamp() * 1000)
+        except Exception:
+            time_ms = 0
+
+        mp_event = {
+            "event": event_name,
+            "properties": {
+                "$device_id": amp_event.get("device_id", ""),
+                "time": time_ms,
+                "ip": amp_event.get("ip_address"),
+                "$city": amp_event.get("city"),
+                "$region": amp_event.get("region"),
+                "mp_country_code": amp_event.get("country"),
+                "$source": "amplitude-to-mixpanel",
+            }
+        }
+
+        # insert_id resolution
+        insert_id = amp_event.get("$insert_id")
+        if insert_id:
+            mp_event["properties"]["$insert_id"] = insert_id
+        else:
+            tuple_str = "-".join([
+                str(amp_event.get("device_id", "")),
+                str(event_time),
+                str(event_name),
+            ])
+            mp_event["properties"]["$insert_id"] = str(mmh3.hash(tuple_str) & 0xFFFFFFFF)
+
+        # Canonical ID resolution
+        user_props = amp_event.get("user_properties", {}) or {}
+        if user_props.get(user_id_key):
+            mp_event["properties"]["$user_id"] = user_props[user_id_key]
+        if amp_event.get(user_id_key):
+            mp_event["properties"]["$user_id"] = amp_event[user_id_key]
+
+        # v2 compat
+        if v2_compat:
+            mp_event["properties"]["distinct_id"] = (
+                mp_event["properties"].get("$user_id")
+                or mp_event["properties"].get("$device_id")
+            )
+
+        # Merge custom props, group props, user props (lower priority than core props)
+        merged = {}
+        for source in [
+            amp_event.get("event_properties", {}),
+            amp_event.get("groups", {}),
+            user_props,
+        ]:
+            if source:
+                merged.update(source)
+
+        # Build remaining amp props (everything not already extracted)
+        remove_keys = _AMP_REMOVE_KEYS | {user_id_key}
+        remaining = {k: v for k, v in amp_event.items() if k not in remove_keys}
+
+        # Apply default property mappings
+        for amp_key, mp_key in AMP_MIX_PAIRS:
+            if amp_key in remaining:
+                merged[mp_key] = remaining.pop(amp_key)
+
+        # Gather everything
+        final_props = {**remaining, **merged, **mp_event["properties"]}
+
+        # Remove experiment props
+        if not include_experiment_props:
+            final_props = {
+                k: v for k, v in final_props.items()
+                if not (k and k.lower().startswith("[experiment]"))
+            }
+
+        mp_event["properties"] = final_props
+        return mp_event
+
+    return transform
+
+
+def amp_user_to_mp(options: dict):
+    """Factory: returns transform for Amplitude users → Mixpanel profiles."""
+    user_id_key = options.get("user_id", "user_id")
+    include_experiment_props = options.get("includeExperimentProps", False)
+
+    def transform(amp_event: dict) -> dict:
+        user_props = amp_event.get("user_properties", {}) or {}
+        if not user_props:
+            return {}
+
+        distinct_id = None
+        if user_props.get(user_id_key):
+            distinct_id = user_props[user_id_key]
+        if amp_event.get(user_id_key):
+            distinct_id = amp_event[user_id_key]
+
+        if not distinct_id:
+            return {}
+
+        profile = {
+            "$distinct_id": distinct_id,
+            "$ip": amp_event.get("ip_address"),
+            "$set": dict(user_props),
+        }
+
+        # Include defaults
+        for amp_key, mp_key in AMP_MIX_PAIRS:
+            if amp_event.get(amp_key):
+                profile["$set"][mp_key] = amp_event[amp_key]
+
+        # Remove experiment props
+        if not include_experiment_props:
+            profile["$set"] = {
+                k: v for k, v in profile["$set"].items()
+                if not (k and k.lower().startswith("[experiment]"))
+            }
+
+        return profile
+
+    return transform
+
+
+def amp_group_to_mp(options: dict):
+    """Factory: returns transform for Amplitude groups → Mixpanel groups."""
+
+    def transform(amp_event: dict) -> dict:
+        group_props = amp_event.get("group_properties", {}) or {}
+        if not group_props:
+            return {}
+        if not amp_event.get("user_id"):
+            return {}
+
+        return {
+            "$group_key": None,
+            "$group_id": None,
+            "$set": group_props,
+        }
+
+    return transform

--- a/src/mixpanel_utils/streaming/vendors/ga4.py
+++ b/src/mixpanel_utils/streaming/vendors/ga4.py
@@ -1,8 +1,5 @@
 """Google Analytics 4 to Mixpanel vendor transforms."""
 
-import mmh3
-
-
 def _flatten_ga_params(ga_params) -> dict:
     """Flatten GA4 event_params array [{key, value: {string_value/int_value/...}}] to flat dict."""
     result = {}
@@ -112,6 +109,8 @@ def ga_events_to_mp(options: dict):
         raise ValueError("insert_id_tup must be a list")
 
     def transform(ga_event: dict) -> dict:
+        import mmh3
+
         mp_event = {
             "event": ga_event.get("event_name", ""),
             "properties": {

--- a/src/mixpanel_utils/streaming/vendors/ga4.py
+++ b/src/mixpanel_utils/streaming/vendors/ga4.py
@@ -1,0 +1,210 @@
+"""Google Analytics 4 to Mixpanel vendor transforms."""
+
+import mmh3
+
+
+def _flatten_ga_params(ga_params) -> dict:
+    """Flatten GA4 event_params array [{key, value: {string_value/int_value/...}}] to flat dict."""
+    result = {}
+    if not ga_params or not isinstance(ga_params, list):
+        return result
+    for param in ga_params:
+        key = param.get("key")
+        value = param.get("value")
+        if key and value and isinstance(value, dict):
+            # Find the *_value key that actually has data
+            for vk in value:
+                if "value" in vk and value[vk] is not None:
+                    result[key] = value[vk]
+    return result
+
+
+def _ga_to_mixpanel_defaults(ga_event: dict) -> dict:
+    """Extract GA4 nested properties and map to Mixpanel defaults."""
+    result = {}
+    geo = ga_event.get("geo") or {}
+    device = ga_event.get("device") or {}
+    web_info = device.get("web_info") or {}
+    app_info = ga_event.get("app_info") or {}
+    traffic = ga_event.get("collected_traffic_source") or {}
+
+    # Geographic
+    if geo.get("city"):
+        result["$city"] = geo["city"]
+    if geo.get("country"):
+        result["mp_country_code"] = geo["country"]
+    if geo.get("region"):
+        result["$region"] = geo["region"]
+
+    # OS
+    if device.get("operating_system"):
+        result["$os"] = device["operating_system"]
+    if device.get("operating_system_version"):
+        result["$os_version"] = device["operating_system_version"]
+
+    # Browser
+    if web_info.get("browser"):
+        result["$browser"] = web_info["browser"]
+    if web_info.get("browser_version"):
+        result["$browser_version"] = web_info["browser_version"]
+
+    # Mobile
+    if device.get("mobile_brand_name"):
+        result["$manufacturer"] = device["mobile_brand_name"]
+    if device.get("mobile_marketing_name"):
+        result["$brand"] = device["mobile_marketing_name"]
+    if device.get("mobile_model_name"):
+        result["$model"] = device["mobile_model_name"]
+
+    # App
+    if app_info.get("version"):
+        result["$app_version_string"] = app_info["version"]
+
+    # Device category
+    if device.get("category"):
+        result["$device"] = device["category"]
+
+    # Current URL from event_params
+    event_params = ga_event.get("event_params")
+    if isinstance(event_params, list):
+        for param in event_params:
+            if param.get("key") == "page_location":
+                val = (param.get("value") or {}).get("string_value")
+                if val:
+                    result["$current_url"] = val
+                    break
+    if "$current_url" not in result and web_info.get("hostname"):
+        result["$current_url"] = web_info["hostname"]
+
+    # Platform → mp_lib
+    platform = (ga_event.get("platform") or "").lower()
+    platform_map = {"web": "web", "android": "android", "ios": "iphone", "unity": "unity"}
+    if platform in platform_map:
+        result["mp_lib"] = platform_map[platform]
+
+    result["$lib_version"] = "ga4-export"
+
+    # UTM
+    if traffic.get("manual_source"):
+        result["utm_source"] = traffic["manual_source"]
+    if traffic.get("manual_medium"):
+        result["utm_medium"] = traffic["manual_medium"]
+    if traffic.get("manual_campaign_name"):
+        result["utm_campaign"] = traffic["manual_campaign_name"]
+    if traffic.get("manual_term"):
+        result["utm_term"] = traffic["manual_term"]
+    if traffic.get("manual_content"):
+        result["utm_content"] = traffic["manual_content"]
+
+    return result
+
+
+def ga_events_to_mp(options: dict):
+    """Factory: returns transform for GA4 events → Mixpanel events."""
+    user_id_key = options.get("user_id", "user_id")
+    device_id_key = options.get("device_id", "user_pseudo_id")
+    insert_id_col = options.get("insert_id_col", "")
+    set_insert_id = options.get("set_insert_id", True)
+    insert_id_tup = options.get("insert_id_tup", ["event_name", "user_pseudo_id", "event_bundle_sequence_id"])
+    time_conversion = options.get("time_conversion", "seconds")
+
+    if not isinstance(insert_id_tup, list):
+        raise ValueError("insert_id_tup must be a list")
+
+    def transform(ga_event: dict) -> dict:
+        mp_event = {
+            "event": ga_event.get("event_name", ""),
+            "properties": {
+                "$device_id": ga_event.get(device_id_key, ""),
+            }
+        }
+
+        # Time conversion (GA4 uses microseconds)
+        event_ts = ga_event.get("event_timestamp", 0)
+        try:
+            event_ts = int(event_ts)
+        except (ValueError, TypeError):
+            event_ts = 0
+
+        if time_conversion in ("seconds", "s"):
+            mp_event["properties"]["time"] = event_ts // 1_000_000
+        elif time_conversion in ("milliseconds", "ms"):
+            mp_event["properties"]["time"] = event_ts // 1_000
+
+        # Insert ID
+        if set_insert_id:
+            if insert_id_col and ga_event.get(insert_id_col):
+                mp_event["properties"]["$insert_id"] = ga_event[insert_id_col]
+            else:
+                tuple_parts = [str(ga_event.get(k, "")) for k in insert_id_tup if ga_event.get(k)]
+                event_id = "-".join(tuple_parts)
+                if event_id:
+                    mp_event["properties"]["$insert_id"] = str(mmh3.hash(event_id) & 0xFFFFFFFF)
+                    mp_event["properties"]["event_id"] = event_id
+
+        mp_event["properties"]["$source"] = "ga4-to-mixpanel"
+
+        # User ID
+        if ga_event.get(user_id_key):
+            mp_event["properties"]["$user_id"] = ga_event[user_id_key]
+
+        # Flatten event_params and get defaults
+        ga_custom = _flatten_ga_params(ga_event.get("event_params", []))
+        ga_defaults = _ga_to_mixpanel_defaults(ga_event)
+
+        # Build remaining GA props (exclude already-processed nested fields)
+        remaining = {k: v for k, v in ga_event.items() if k not in ("event_params", "user_properties")}
+
+        # Merge: remaining + defaults + custom params + core props (highest priority)
+        mp_event["properties"] = {**remaining, **ga_defaults, **ga_custom, **mp_event["properties"]}
+        return mp_event
+
+    return transform
+
+
+def ga_user_to_mp(options: dict):
+    """Factory: returns transform for GA4 users → Mixpanel profiles."""
+    user_id_key = options.get("user_id", "user_id")
+
+    def transform(ga_event: dict) -> dict:
+        user_props = _flatten_ga_params(ga_event.get("user_properties", []))
+        if not user_props:
+            return {}
+
+        distinct_id = None
+        if isinstance(ga_event.get("user_properties"), dict) and ga_event["user_properties"].get(user_id_key):
+            distinct_id = ga_event["user_properties"][user_id_key]
+        if ga_event.get(user_id_key):
+            distinct_id = ga_event[user_id_key]
+
+        if not distinct_id:
+            return {}
+
+        defaults = _ga_to_mixpanel_defaults(ga_event)
+
+        return {
+            "$distinct_id": distinct_id,
+            "$ip": 0,
+            "$set": {**defaults, **user_props},
+        }
+
+    return transform
+
+
+def ga_groups_to_mp(options: dict):
+    """Factory: returns transform for GA4 groups → Mixpanel groups."""
+
+    def transform(ga_event: dict) -> dict:
+        group_props = ga_event.get("group_properties", {}) or {}
+        if not group_props:
+            return {}
+        if not ga_event.get("user_id"):
+            return {}
+
+        return {
+            "$group_key": None,
+            "$group_id": None,
+            "$set": group_props,
+        }
+
+    return transform

--- a/src/mixpanel_utils/streaming/vendors/ga4.py
+++ b/src/mixpanel_utils/streaming/vendors/ga4.py
@@ -138,7 +138,7 @@ def ga_events_to_mp(options: dict):
                 tuple_parts = [str(ga_event.get(k, "")) for k in insert_id_tup if ga_event.get(k)]
                 event_id = "-".join(tuple_parts)
                 if event_id:
-                    mp_event["properties"]["$insert_id"] = str(mmh3.hash(event_id) & 0xFFFFFFFF)
+                    mp_event["properties"]["$insert_id"] = str(mmh3.hash(event_id, signed=False))
                     mp_event["properties"]["event_id"] = event_id
 
         mp_event["properties"]["$source"] = "ga4-to-mixpanel"

--- a/src/mixpanel_utils/streaming/vendors/heap.py
+++ b/src/mixpanel_utils/streaming/vendors/heap.py
@@ -2,7 +2,6 @@
 
 import hashlib
 import json
-from dateutil import parser as dateparser
 from datetime import timezone
 from pathlib import Path
 
@@ -57,6 +56,8 @@ def _parse_heap_id(id_str: str) -> str:
 
 def _parse_time(time_str) -> int:
     """Parse a time value to milliseconds."""
+    from dateutil import parser as dateparser
+
     if isinstance(time_str, (int, float)):
         val = int(time_str)
         if len(str(abs(val))) >= 13:
@@ -155,6 +156,8 @@ def heap_user_to_mp(options: dict):
 
         if not user_id and not custom_id:
             return {}
+
+        from dateutil import parser as dateparser
 
         for field in ("last_modified", "joindate", "identity_time"):
             if heap_user.get(field):

--- a/src/mixpanel_utils/streaming/vendors/heap.py
+++ b/src/mixpanel_utils/streaming/vendors/heap.py
@@ -1,0 +1,193 @@
+"""Heap to Mixpanel vendor transforms."""
+
+import hashlib
+import json
+from dateutil import parser as dateparser
+from datetime import timezone
+from pathlib import Path
+
+# Heap → Mixpanel default property mappings
+HEAP_MP_PAIRS = [
+    ("joindate", "$created"),
+    ("initial_utm_term", "$initial_utm_term"),
+    ("initial_utm_source", "$initial_utm_source"),
+    ("initial_utm_medium", "$initial_utm_medium"),
+    ("initial_utm_content", "$initial_utm_content"),
+    ("initial_utm_campaign", "$initial_utm_campaign"),
+    ("initial_search_keyword", "$initial_search_keyword"),
+    ("initial_region", "$region"),
+    ("initial_referrer", "$initial_referrer"),
+    ("initial_platform", "$os"),
+    ("initial_browser", "$browser"),
+    ("app_version", "$app_version_string"),
+    ("device_brand", "$brand"),
+    ("device_manufacturer", "$manufacturer"),
+    ("device_model", "$model"),
+    ("region", "$region"),
+    ("initial_city", "$city"),
+    ("initial_country", "$country_code"),
+    ("email", "$email"),
+    ("_email", "$email"),
+    ("firstName", "$first_name"),
+    ("lastName", "$last_name"),
+    ("last_modified", "$last_seen"),
+    ("Name", "$name"),
+    ("city", "$city"),
+    ("country", "$country_code"),
+    ("ip", "$ip"),
+]
+
+
+def _build_device_id_map(file_path: str) -> dict:
+    """Build a device_id → distinct_id mapping from a JSON file."""
+    path = Path(file_path)
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return {item["id"]: item["distinct_id"] for item in data if "id" in item}
+
+
+def _parse_heap_id(id_str: str) -> str:
+    """Extract the second number from a heap tuple ID like '(2008543124,4810060720600030)'."""
+    if not id_str:
+        return ""
+    try:
+        return id_str.split(",")[1].replace(")", "").strip()
+    except (IndexError, AttributeError):
+        return ""
+
+
+def _parse_time(time_str) -> int:
+    """Parse a time value to milliseconds."""
+    if isinstance(time_str, (int, float)):
+        val = int(time_str)
+        if len(str(abs(val))) >= 13:
+            return val
+        return val * 1000
+    try:
+        ts = dateparser.parse(str(time_str))
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        return int(ts.timestamp() * 1000)
+    except Exception:
+        return 0
+
+
+def heap_events_to_mp(options: dict):
+    """Factory: returns transform for Heap events → Mixpanel events."""
+    user_id_key = options.get("user_id", "")
+    device_id_file = options.get("device_id_file", "")
+
+    device_id_map = {}
+    if device_id_file:
+        device_id_map = _build_device_id_map(device_id_file)
+
+    def transform(heap_event: dict) -> dict:
+        event_id = heap_event.get("event_id")
+        if event_id:
+            insert_id = str(event_id)
+        else:
+            insert_id = hashlib.md5(json.dumps(heap_event, sort_keys=True).encode()).hexdigest()
+
+        anon_id = _parse_heap_id(heap_event.get("id", ""))
+        if heap_event.get("user_id"):
+            device_id = str(heap_event["user_id"])
+        else:
+            device_id = str(anon_id)
+
+        if not device_id:
+            return {}
+
+        event_name = heap_event.get("type") or heap_event.get("object") or "unknown action"
+        time_ms = _parse_time(heap_event.get("time", ""))
+        custom_props = dict(heap_event.get("properties", {}) or {})
+        remaining = {k: v for k, v in heap_event.items() if k not in ("properties", "time")}
+
+        mp_event = {
+            "event": event_name,
+            "properties": {
+                "$device_id": device_id,
+                "time": time_ms,
+                "$insert_id": insert_id,
+                "$source": "heap-to-mixpanel",
+            }
+        }
+
+        merged = {**remaining, **custom_props, **mp_event["properties"]}
+
+        for heap_key, mp_key in HEAP_MP_PAIRS:
+            if heap_key in merged:
+                merged[mp_key] = merged.pop(heap_key)
+
+        if not user_id_key:
+            identity = heap_event.get("identity")
+            if identity:
+                merged["$device_id"] = device_id
+                merged["$user_id"] = str(identity)
+                mp_event["event"] = "identity association"
+            elif device_id_map:
+                known_id = device_id_map.get(device_id)
+                if known_id:
+                    merged["$user_id"] = known_id
+
+        if user_id_key and heap_event.get(user_id_key):
+            val = heap_event[user_id_key]
+            if isinstance(val, (str, int, float)):
+                merged["$user_id"] = str(val)
+
+        mp_event["properties"] = merged
+        return mp_event
+
+    return transform
+
+
+def heap_user_to_mp(options: dict):
+    """Factory: returns transform for Heap users → Mixpanel profiles."""
+    user_id_key = options.get("user_id", "")
+
+    def transform(heap_user: dict) -> dict:
+        custom_id = None
+        if user_id_key and heap_user.get(user_id_key):
+            val = heap_user[user_id_key]
+            if isinstance(val, (str, int, float)):
+                custom_id = str(val)
+
+        anon_id = _parse_heap_id(heap_user.get("id", ""))
+        user_id = heap_user.get("identity")
+
+        if not user_id and not custom_id:
+            return {}
+
+        for field in ("last_modified", "joindate", "identity_time"):
+            if heap_user.get(field):
+                try:
+                    ts = dateparser.parse(str(heap_user[field]))
+                    if ts.tzinfo is None:
+                        ts = ts.replace(tzinfo=timezone.utc)
+                    heap_user[field] = ts.isoformat()
+                except Exception:
+                    pass
+
+        custom_props = dict(heap_user.get("properties", {}) or {})
+        default_props = {k: v for k, v in heap_user.items() if k != "properties"}
+
+        profile = {
+            "$distinct_id": custom_id or user_id or anon_id,
+            "$ip": heap_user.get("initial_ip"),
+            "$set": {**default_props, **custom_props},
+        }
+
+        for heap_key, mp_key in HEAP_MP_PAIRS:
+            if heap_key in profile["$set"]:
+                profile["$set"][mp_key] = profile["$set"].pop(heap_key)
+
+        return profile
+
+    return transform
+
+
+def heap_group_to_mp(options: dict):
+    """Factory: returns transform for Heap groups → Mixpanel groups (stub)."""
+
+    def transform(heap_group: dict) -> dict:
+        return {}
+
+    return transform

--- a/src/mixpanel_utils/streaming/vendors/june.py
+++ b/src/mixpanel_utils/streaming/vendors/june.py
@@ -31,7 +31,7 @@ def _safe_json_parse(val):
 def june_events_to_mp(options: dict = None):
     """Factory: returns transform for June events → Mixpanel events."""
     options = options or {}
-    v2_compat = options.get("v2compat", True)
+    v2_compat = options.get("v2_compat", True)
 
     def transform(june_event: dict) -> dict:
         import mmh3
@@ -70,10 +70,10 @@ def june_events_to_mp(options: dict = None):
         # Insert ID
         delivery_id = properties.get("delivery_id") if isinstance(properties, dict) else None
         if delivery_id:
-            mp_props["$insert_id"] = str(mmh3.hash(str(delivery_id)) & 0xFFFFFFFF)
+            mp_props["$insert_id"] = str(mmh3.hash(str(delivery_id), signed=False))
         else:
             tuple_str = "-".join([str(anonymous_id), str(user_id), str(name), str(timestamp)])
-            mp_props["$insert_id"] = str(mmh3.hash(tuple_str) & 0xFFFFFFFF)
+            mp_props["$insert_id"] = str(mmh3.hash(tuple_str, signed=False))
 
         # Identity
         if anonymous_id:

--- a/src/mixpanel_utils/streaming/vendors/june.py
+++ b/src/mixpanel_utils/streaming/vendors/june.py
@@ -1,8 +1,6 @@
 """June.so to Mixpanel vendor transforms."""
 
 import json
-import mmh3
-from dateutil import parser as dateparser
 from datetime import timezone
 
 # June → Mixpanel field mappings
@@ -36,6 +34,9 @@ def june_events_to_mp(options: dict = None):
     v2_compat = options.get("v2compat", True)
 
     def transform(june_event: dict) -> dict:
+        import mmh3
+        from dateutil import parser as dateparser
+
         anonymous_id = june_event.get("anonymous_id", "")
         context = _safe_json_parse(june_event.get("context", "{}"))
         name = june_event.get("name", "")

--- a/src/mixpanel_utils/streaming/vendors/june.py
+++ b/src/mixpanel_utils/streaming/vendors/june.py
@@ -1,0 +1,207 @@
+"""June.so to Mixpanel vendor transforms."""
+
+import json
+import mmh3
+from dateutil import parser as dateparser
+from datetime import timezone
+
+# June → Mixpanel field mappings
+JUNE_MIX_PAIRS = [
+    ("user_id", "$user_id"),
+    ("anonymous_id", "anonymous_id"),
+    ("timestamp", "time"),
+    ("firstName", "$first_name"),
+    ("lastName", "$last_name"),
+    ("email", "$email"),
+    ("phoneNumber", "$phone"),
+    ("creationDate", "$created"),
+    ("ip", "$ip"),
+    ("name", "$name"),
+]
+
+
+def _safe_json_parse(val):
+    """Try to parse a string as JSON, return original if it fails."""
+    if isinstance(val, str):
+        try:
+            return json.loads(val)
+        except (json.JSONDecodeError, ValueError):
+            pass
+    return val
+
+
+def june_events_to_mp(options: dict = None):
+    """Factory: returns transform for June events → Mixpanel events."""
+    options = options or {}
+    v2_compat = options.get("v2compat", True)
+
+    def transform(june_event: dict) -> dict:
+        anonymous_id = june_event.get("anonymous_id", "")
+        context = _safe_json_parse(june_event.get("context", "{}"))
+        name = june_event.get("name", "")
+        properties = _safe_json_parse(june_event.get("properties", "{}"))
+        timestamp = june_event.get("timestamp", "")
+        event_type = june_event.get("type", "")
+        user_id = june_event.get("user_id", "")
+
+        if not isinstance(properties, dict):
+            properties = {}
+        if not isinstance(context, dict):
+            context = {}
+
+        # Parse time
+        try:
+            ts = dateparser.parse(str(timestamp))
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+            time_ms = int(ts.timestamp() * 1000)
+        except Exception:
+            time_ms = 0
+
+        mp_props = {
+            "time": time_ms,
+            "$source": "june-to-mixpanel",
+            "type": event_type,
+            **properties,
+            **context,
+        }
+
+        # Insert ID
+        delivery_id = properties.get("delivery_id") if isinstance(properties, dict) else None
+        if delivery_id:
+            mp_props["$insert_id"] = str(mmh3.hash(str(delivery_id)) & 0xFFFFFFFF)
+        else:
+            tuple_str = "-".join([str(anonymous_id), str(user_id), str(name), str(timestamp)])
+            mp_props["$insert_id"] = str(mmh3.hash(tuple_str) & 0xFFFFFFFF)
+
+        # Identity
+        if anonymous_id:
+            mp_props["$device_id"] = anonymous_id
+        if user_id:
+            mp_props["$user_id"] = user_id
+
+        if v2_compat:
+            if user_id:
+                mp_props["distinct_id"] = user_id
+            elif anonymous_id:
+                mp_props["distinct_id"] = anonymous_id
+
+        # Extract context properties
+        if isinstance(context, dict):
+            page = context.get("page")
+            if isinstance(page, dict):
+                if page.get("url"):
+                    mp_props["$current_url"] = page["url"]
+                if page.get("path"):
+                    mp_props["$pathname"] = page["path"]
+                if page.get("referrer"):
+                    mp_props["$referrer"] = page["referrer"]
+                if page.get("search"):
+                    mp_props["$search"] = page["search"]
+                if page.get("title"):
+                    mp_props["$title"] = page["title"]
+
+            if context.get("userAgent"):
+                mp_props["$browser"] = context["userAgent"]
+            if context.get("ip"):
+                mp_props["ip"] = context["ip"]
+            if context.get("locale"):
+                mp_props["$locale"] = context["locale"]
+
+            library = context.get("library")
+            if isinstance(library, dict):
+                if library.get("name"):
+                    mp_props["$lib"] = library["name"]
+                if library.get("version"):
+                    mp_props["$lib_version"] = library["version"]
+
+            integration = context.get("integration")
+            if isinstance(integration, dict):
+                if integration.get("name"):
+                    mp_props["integration_name"] = integration["name"]
+                if integration.get("version"):
+                    mp_props["integration_version"] = integration["version"]
+
+        return {
+            "event": name or "unnamed june event",
+            "properties": mp_props,
+        }
+
+    return transform
+
+
+def june_user_to_mp(options: dict = None):
+    """Factory: returns transform for June users → Mixpanel profiles."""
+    options = options or {}
+
+    june_mix_map = dict(JUNE_MIX_PAIRS)
+
+    def transform(june_user: dict) -> dict:
+        user_id = june_user.get("user_id", "")
+        if not user_id:
+            return {}
+
+        traits = _safe_json_parse(june_user.get("traits", {}))
+        context = _safe_json_parse(june_user.get("context", {}))
+
+        if not isinstance(traits, dict):
+            traits = {}
+        if not isinstance(context, dict):
+            context = {}
+
+        props = {**context, **traits}
+
+        # Remap known keys
+        for key in list(props.keys()):
+            mp_key = june_mix_map.get(key)
+            if mp_key:
+                props[mp_key] = props.pop(key)
+
+        return {
+            "$distinct_id": user_id,
+            "$set": {
+                "$source": "june-to-mixpanel",
+                **props,
+            }
+        }
+
+    return transform
+
+
+def june_group_to_mp(options: dict = None):
+    """Factory: returns transform for June groups → Mixpanel groups."""
+    options = options or {}
+    group_key = options.get("group_key", "group_id")
+
+    june_mix_map = dict(JUNE_MIX_PAIRS)
+
+    def transform(june_group: dict) -> dict:
+        group_id = june_group.get("group_id", "")
+        if not group_id:
+            return {}
+
+        traits = _safe_json_parse(june_group.get("traits", {}))
+        context = _safe_json_parse(june_group.get("context", {}))
+
+        if not isinstance(traits, dict):
+            traits = {}
+        if not isinstance(context, dict):
+            context = {}
+
+        props = {**traits, **context}
+
+        for key in list(props.keys()):
+            mp_key = june_mix_map.get(key)
+            if mp_key:
+                props[mp_key] = props.pop(key)
+
+        return {
+            "$group_id": group_id,
+            "$group_key": group_key,
+            "$set": {
+                "$source": "june-to-mixpanel",
+                **props,
+            }
+        }
+
+    return transform

--- a/src/mixpanel_utils/streaming/vendors/mixpanel.py
+++ b/src/mixpanel_utils/streaming/vendors/mixpanel.py
@@ -1,0 +1,31 @@
+"""Mixpanel re-import vendor transform.
+
+Transforms Mixpanel export format back into Mixpanel import format.
+Used for migrating data between projects or re-importing exported data.
+"""
+
+
+def mixpanel_events_to_mixpanel(options: dict = None):
+    """Factory: returns transform for Mixpanel export format → Mixpanel import format."""
+    options = options or {}
+
+    def transform(mp_event: dict) -> dict:
+        final_properties = dict(mp_event.get("properties", {}))
+
+        if mp_event.get("device_id"):
+            final_properties["$device_id"] = mp_event["device_id"]
+        if mp_event.get("distinct_id"):
+            final_properties["distinct_id"] = mp_event["distinct_id"]
+        if mp_event.get("insert_id"):
+            final_properties["$insert_id"] = mp_event["insert_id"]
+        if mp_event.get("time"):
+            final_properties["time"] = mp_event["time"]
+        if mp_event.get("user_id"):
+            final_properties["$user_id"] = mp_event["user_id"]
+
+        return {
+            "event": mp_event.get("event_name") or mp_event.get("event") or "unnamed",
+            "properties": final_properties,
+        }
+
+    return transform

--- a/src/mixpanel_utils/streaming/vendors/mparticle.py
+++ b/src/mixpanel_utils/streaming/vendors/mparticle.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import mmh3
-
 BAD_USER_IDS = {
     "-1", "0", "00000000-0000-0000-0000-000000000000", "<nil>", "]",
     "anon", "anonymous", "false", "lmy47d", "n/a", "na", "nil", "none",
@@ -56,6 +54,8 @@ def mparticle_events_to_mixpanel(options: dict):
     include_source_info = options.get("source_info", True)
 
     def transform(mp_batch: dict) -> list[dict]:
+        import mmh3
+
         events = mp_batch.get("events", [])
         user_identities = mp_batch.get("user_identities", []) or []
 

--- a/src/mixpanel_utils/streaming/vendors/mparticle.py
+++ b/src/mixpanel_utils/streaming/vendors/mparticle.py
@@ -143,7 +143,7 @@ def mparticle_events_to_mixpanel(options: dict):
                 mp["properties"]["$insert_id"] = insert_id
             else:
                 tuple_str = "-".join([anon_id, str(timestamp), event_type])
-                mp["properties"]["$insert_id"] = str(mmh3.hash(tuple_str) & 0xFFFFFFFF)
+                mp["properties"]["$insert_id"] = str(mmh3.hash(tuple_str, signed=False))
 
             # Custom event name
             if event_type == "custom_event":

--- a/src/mixpanel_utils/streaming/vendors/mparticle.py
+++ b/src/mixpanel_utils/streaming/vendors/mparticle.py
@@ -1,5 +1,7 @@
 """mParticle to Mixpanel vendor transforms."""
 
+from __future__ import annotations
+
 import mmh3
 
 BAD_USER_IDS = {

--- a/src/mixpanel_utils/streaming/vendors/mparticle.py
+++ b/src/mixpanel_utils/streaming/vendors/mparticle.py
@@ -1,0 +1,238 @@
+"""mParticle to Mixpanel vendor transforms."""
+
+import mmh3
+
+BAD_USER_IDS = {
+    "-1", "0", "00000000-0000-0000-0000-000000000000", "<nil>", "]",
+    "anon", "anonymous", "false", "lmy47d", "n/a", "na", "nil", "none",
+    "null", "true", "undefined", "unknown", "{}",
+}
+
+
+def _flatten_nested(obj: dict, prefix: str = "") -> dict:
+    """Flatten nested dicts into dot-notation keys."""
+    result = {}
+    if not isinstance(obj, dict):
+        return result
+    for key, value in obj.items():
+        full_key = f"{prefix}{key}" if not prefix else f"{prefix}.{key}"
+        if isinstance(value, dict):
+            result.update(_flatten_nested(value, full_key))
+        else:
+            result[full_key] = value
+    return result
+
+
+def _flatten_props(record: dict) -> dict:
+    """Flatten a properties dict (top-level only, like the Node transforms.flattenProperties)."""
+    if not isinstance(record, dict):
+        return {}
+    result = {}
+    for key, value in record.items():
+        if isinstance(value, dict):
+            for sub_key, sub_value in value.items():
+                result[f"{key}.{sub_key}"] = sub_value
+        else:
+            result[key] = value
+    return result
+
+
+def mparticle_events_to_mixpanel(options: dict):
+    """Factory: returns transform for mParticle batches → list of Mixpanel events.
+
+    Note: mParticle sends batches containing multiple events. This transform
+    returns a LIST of Mixpanel events from a single mParticle batch.
+    """
+    user_id_keys = options.get("user_id", ["customer_id"])
+    device_id_keys = options.get("device_id", ["mp_deviceid", "mpid", "session_uuid"])
+    insert_id_key = options.get("insert_id", "event_id")
+    include_user_attributes = options.get("user_attributes", False)
+    include_context = options.get("context", False)
+    include_identities = options.get("identities", False)
+    include_application_info = options.get("application_info", True)
+    include_device_info = options.get("device_info", True)
+    include_source_info = options.get("source_info", True)
+
+    def transform(mp_batch: dict) -> list[dict]:
+        events = mp_batch.get("events", [])
+        user_identities = mp_batch.get("user_identities", []) or []
+
+        # Resolve user_id
+        known_id = ""
+        for id_type in user_id_keys:
+            for identity in user_identities:
+                if identity.get("identity_type") == id_type:
+                    val = identity.get("identity")
+                    if val and str(val) not in BAD_USER_IDS:
+                        known_id = str(val)
+                        break
+            if known_id:
+                break
+
+        # Resolve device_id
+        anon_id = ""
+        for id_type in device_id_keys:
+            # Check user_identities
+            for identity in user_identities:
+                if identity.get("identity_type") == id_type and identity.get("identity"):
+                    anon_id = str(identity["identity"])
+                    break
+            if anon_id:
+                break
+
+            # Check top level
+            if mp_batch.get(id_type):
+                anon_id = str(mp_batch[id_type])
+                break
+
+            # Check event data
+            for event in events:
+                data = event.get("data", {}) or {}
+                if data.get(id_type):
+                    anon_id = str(data[id_type])
+                    break
+            if anon_id:
+                break
+
+        # Inherited props from batch level
+        inherited_props = {
+            "batch_id": mp_batch.get("batch_id"),
+            "message_id": mp_batch.get("message_id"),
+            "message_type": mp_batch.get("message_type"),
+            "unique_id": mp_batch.get("unique_id"),
+            "source_request_id": mp_batch.get("source_request_id"),
+            "schema_version": mp_batch.get("schema_version"),
+        }
+
+        # Additional properties based on options
+        if include_user_attributes and mp_batch.get("user_attributes"):
+            inherited_props.update(mp_batch["user_attributes"])
+        if include_context and mp_batch.get("context"):
+            inherited_props.update(_flatten_props(mp_batch["context"]))
+        if include_identities:
+            inherited_props["identities"] = user_identities
+        if include_application_info and mp_batch.get("application_info"):
+            inherited_props.update(mp_batch["application_info"])
+        if include_device_info and mp_batch.get("device_info"):
+            inherited_props.update(mp_batch["device_info"])
+        if include_source_info and mp_batch.get("source_info"):
+            inherited_props.update(mp_batch["source_info"])
+
+        mixpanel_events = []
+
+        for mp_event in events:
+            data = mp_event.get("data", {}) or {}
+            timestamp = data.get("timestamp_unixtime_ms", 0)
+            event_type = mp_event.get("event_type", "")
+
+            insert_id = data.get(insert_id_key)
+
+            mp = {
+                "event": event_type,
+                "properties": {
+                    "$device_id": anon_id,
+                    "time": int(timestamp) if timestamp else 0,
+                    "$source": "mparticle-to-mixpanel",
+                }
+            }
+
+            # Insert ID
+            if insert_id:
+                mp["properties"]["$insert_id"] = insert_id
+            else:
+                tuple_str = "-".join([anon_id, str(timestamp), event_type])
+                mp["properties"]["$insert_id"] = str(mmh3.hash(tuple_str) & 0xFFFFFFFF)
+
+            # Custom event name
+            if event_type == "custom_event":
+                mp["event"] = data.get("event_name", event_type)
+
+            # User ID
+            if known_id:
+                mp["properties"]["$user_id"] = known_id
+
+            # Custom attributes (flattened)
+            custom_attrs = data.get("custom_attributes", {}) or {}
+            custom_props = _flatten_props(custom_attrs)
+
+            # Standard data props (flattened, minus custom_attributes)
+            standard_data = {k: v for k, v in data.items() if k != "custom_attributes"}
+            standard_props = _flatten_props(standard_data)
+
+            # Merge all
+            mp["properties"] = {
+                **inherited_props,
+                **standard_props,
+                **custom_props,
+                **mp["properties"],
+            }
+
+            mixpanel_events.append(mp)
+
+        return mixpanel_events
+
+    return transform
+
+
+def mparticle_user_to_mixpanel(options: dict):
+    """Factory: returns transform for mParticle users → Mixpanel profiles."""
+    user_id_keys = options.get("user_id", ["customer_id"])
+
+    def transform(mp_batch: dict) -> dict:
+        user_identities = mp_batch.get("user_identities", []) or []
+
+        known_id = ""
+        for id_type in user_id_keys:
+            for identity in user_identities:
+                if identity.get("identity_type") == id_type:
+                    val = identity.get("identity")
+                    if val and str(val) not in BAD_USER_IDS:
+                        known_id = str(val)
+                        break
+            if known_id:
+                break
+
+        if not known_id:
+            return {}
+
+        user_props = mp_batch.get("user_attributes", {}) or {}
+        if not user_props:
+            return {}
+
+        inherited = {
+            **(mp_batch.get("application_info", {}) or {}),
+            **(mp_batch.get("device_info", {}) or {}),
+            "identities": user_identities,
+            "mpid": mp_batch.get("mpid"),
+        }
+
+        profile = {
+            "$distinct_id": known_id,
+            "$set": {**inherited, **user_props},
+        }
+
+        if mp_batch.get("ip"):
+            profile["$ip"] = mp_batch["ip"]
+
+        return profile
+
+    return transform
+
+
+def mparticle_group_to_mixpanel(options: dict):
+    """Factory: returns transform for mParticle groups → Mixpanel groups."""
+
+    def transform(mp_batch: dict) -> dict:
+        group_props = mp_batch.get("group_properties", {}) or {}
+        if not group_props:
+            return {}
+        if not mp_batch.get("user_id"):
+            return {}
+
+        return {
+            "$group_key": None,
+            "$group_id": None,
+            "$set": group_props,
+        }
+
+    return transform

--- a/src/mixpanel_utils/streaming/vendors/posthog.py
+++ b/src/mixpanel_utils/streaming/vendors/posthog.py
@@ -1,0 +1,272 @@
+"""PostHog to Mixpanel vendor transforms."""
+
+import re
+import json
+from dateutil import parser as dateparser
+from datetime import datetime, timezone
+
+
+def _add_if_defined(target: dict, key: str, value):
+    """Add key to target only if value is not None."""
+    if value is not None:
+        target[key] = value
+
+
+# PostHog → Mixpanel profile property mappings
+POSTHOG_MIX_PROFILE_PAIRS = [
+    ("name", "$name"),
+    ("first_name", "$first_name"),
+    ("last_name", "$last_name"),
+    ("email", "$email"),
+    ("phone", "$phone"),
+    ("avatar", "$avatar"),
+    ("$geoip_city_name", "$city"),
+    ("$geoip_subdivision_1_name", "$region"),
+    ("$geoip_country_code", "$country_code"),
+    (None, "$locale"),
+    (None, "$geo_source"),
+    ("$geoip_time_zone", "$timezone"),
+    ("$os", "$os"),
+    ("$browser", "$browser"),
+    ("$browser_version", "$browser_version"),
+    ("$initial_referrer", "$initial_referrer"),
+    ("$initial_referring_domain", "$initial_referring_domain"),
+    ("$initial_utm_source", "initial_utm_source"),
+    ("$initial_utm_medium", "initial_utm_medium"),
+    ("$initial_utm_campaign", "initial_utm_campaign"),
+    ("$initial_utm_content", "initial_utm_content"),
+    ("$initial_utm_term", "initial_utm_term"),
+    (None, "$android_manufacturer"),
+    (None, "$android_brand"),
+    (None, "$android_model"),
+    (None, "$ios_device_model"),
+]
+
+
+def _build_regex(patterns: list[str]) -> re.Pattern:
+    """Build a compiled regex that matches any of the given prefixes."""
+    escaped = [re.escape(p) for p in patterns]
+    return re.compile(f"^({'|'.join(escaped)})")
+
+
+def posthog_events_to_mp(options: dict, heavy_objects: dict | None = None):
+    """Factory: returns transform for PostHog events → Mixpanel events."""
+    v2_compat = options.get("v2_compat", False)
+    ignore_events = options.get("ignore_events", [
+        "$feature", "$set", "$webvitals", "$pageleave", "$groupidentify",
+        "$autocapture", "$rageclick", "$screen", "$capture_pageview",
+        "$merge_dangerously",
+    ])
+    identify_events = options.get("identify_events", ["$identify"])
+    ignore_props = options.get("ignore_props", [
+        "$feature/", "$feature_flag_", "$replay_", "$sdk_debug",
+        "$session_recording", "$set", "$set_once",
+    ])
+
+    heavy_objects = heavy_objects or {}
+    person_map = heavy_objects.get("people", {})
+
+    # Pre-compile regex patterns
+    delete_prefixes = ["token", *ignore_props]
+    delete_prop_pattern = _build_regex(delete_prefixes)
+    ignore_event_pattern = _build_regex(ignore_events)
+
+    def transform(posthog_event: dict) -> dict | None:
+        event_name = posthog_event.get("event", "")
+        posthog_distinct_id = posthog_event.get("distinct_id")
+        mp_ip = posthog_event.get("ip")
+        mp_timestamp = posthog_event.get("timestamp")
+        mp_insert_id = posthog_event.get("uuid")
+        posthog_properties = posthog_event.get("properties", {})
+
+        # Filter ignored events
+        if ignore_event_pattern.search(event_name or ""):
+            return None
+
+        # Parse properties if string
+        if isinstance(posthog_properties, str):
+            try:
+                posthog_properties = json.loads(posthog_properties)
+            except json.JSONDecodeError:
+                posthog_properties = {}
+        posthog_properties = posthog_properties or {}
+
+        # Extract known fields
+        mp_city = posthog_properties.pop("$geoip_city_name", None)
+        mp_country_code = posthog_properties.pop("$geoip_country_code", None)
+        mp_latitude = posthog_properties.pop("$geoip_latitude", None)
+        mp_longitude = posthog_properties.pop("$geoip_longitude", None)
+        posthog_user_id = posthog_properties.pop("$user_id", None)
+        posthog_device_id = posthog_properties.pop("$device_id", None)
+
+        # Core Mixpanel props
+        try:
+            ts = dateparser.parse(str(mp_timestamp))
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+            time_ms = int(ts.timestamp() * 1000)
+        except Exception:
+            time_ms = 0
+
+        mp_props = {
+            "time": time_ms,
+            "$source": "posthog-to-mixpanel",
+        }
+        _add_if_defined(mp_props, "ip", mp_ip)
+        _add_if_defined(mp_props, "$city", mp_city)
+        _add_if_defined(mp_props, "$region", mp_country_code)
+        _add_if_defined(mp_props, "mp_country_code", posthog_event.get("country"))
+        _add_if_defined(mp_props, "$insert_id", mp_insert_id)
+        _add_if_defined(mp_props, "$latitude", mp_latitude)
+        _add_if_defined(mp_props, "$longitude", mp_longitude)
+
+        # Identity resolution
+        user_id = posthog_user_id
+        device_id = posthog_device_id
+        distinct_id = posthog_distinct_id
+
+        # Check person map
+        if posthog_distinct_id and isinstance(person_map, dict):
+            mapped = person_map.get(posthog_distinct_id)
+            if mapped:
+                user_id = mapped
+
+        if user_id:
+            mp_props["$user_id"] = user_id
+        if device_id:
+            mp_props["$device_id"] = device_id
+        if distinct_id:
+            mp_props["distinct_id"] = distinct_id
+
+        # Remove ignored props
+        remaining = {
+            k: v for k, v in posthog_properties.items()
+            if not delete_prop_pattern.search(k)
+        }
+
+        # Assemble
+        mp_event = {"event": event_name, "properties": {**mp_props, **remaining}}
+        mp_event["properties"].pop("token", None)
+
+        # ID merge v2
+        if v2_compat:
+            if device_id:
+                mp_event["properties"]["distinct_id"] = device_id
+            if user_id:
+                mp_event["properties"]["distinct_id"] = user_id
+
+            if event_name and event_name.startswith("$identify"):
+                mp_event["properties"]["$identified_id"] = user_id
+                mp_event["properties"]["$anon_id"] = device_id
+
+        # ID merge v3
+        if not v2_compat:
+            if any(event_name == evt for evt in identify_events):
+                props = posthog_event.get("properties", {})
+                if isinstance(props, str):
+                    try:
+                        props = json.loads(props)
+                    except json.JSONDecodeError:
+                        props = {}
+                anon_distinct_id = props.get("$anon_distinct_id")
+                ph_device_id = props.get("$device_id")
+                session_id = props.get("$session_id")
+
+                identify_props = {
+                    "$user_id": distinct_id,
+                    "$device_id": ph_device_id or anon_distinct_id,
+                    "$insert_id": mp_insert_id,
+                    **mp_props,
+                }
+                _add_if_defined(identify_props, "$session_id", session_id)
+
+                return {
+                    "event": "identity association",
+                    "properties": identify_props,
+                }
+
+        return mp_event
+
+    return transform
+
+
+def posthog_person_to_mp_profile(options: dict, heavy_objects: dict | None = None):
+    """Factory: returns transform for PostHog persons → Mixpanel profiles."""
+    directive = options.get("directive", "$set")
+    ignore_props = options.get("ignore_props", ["$creator_event_uuid"])
+
+    delete_prefixes = ["token", *ignore_props]
+    delete_prop_pattern = _build_regex(delete_prefixes)
+
+    def transform(posthog_person: dict) -> dict | None:
+        distinct_id = posthog_person.get("distinct_id")
+        created_at = posthog_person.get("created_at")
+        user_properties = posthog_person.get("properties", {}) or {}
+
+        if not distinct_id:
+            return {}
+
+        mp_props = {}
+
+        # Map known profile pairs
+        mapped_keys = set()
+        for ph_key, mp_key in POSTHOG_MIX_PROFILE_PAIRS:
+            if ph_key is None:
+                continue
+            val = user_properties.get(ph_key)
+            if val is not None:
+                mp_props[mp_key] = val
+                mapped_keys.add(ph_key)
+
+        # Add remaining props
+        for key, value in user_properties.items():
+            if key in mapped_keys:
+                continue
+            if delete_prop_pattern.search(key):
+                continue
+            if value is None:
+                continue
+            mp_props[key] = value
+
+        # Created timestamp
+        created_str = None
+        if created_at is not None:
+            try:
+                if isinstance(created_at, (int, float)):
+                    created_str = datetime.fromtimestamp(created_at, tz=timezone.utc).isoformat()
+                else:
+                    ts = dateparser.parse(str(created_at))
+                    if ts.tzinfo is None:
+                        ts = ts.replace(tzinfo=timezone.utc)
+                    created_str = ts.isoformat()
+            except Exception:
+                pass
+
+        dir_props = {}
+        if created_str:
+            dir_props["$created"] = created_str
+        dir_props.update(mp_props)
+
+        profile = {
+            "$distinct_id": distinct_id,
+            directive: dir_props,
+        }
+
+        # Latitude/longitude at top level
+        for init_key, final_key in [
+            ("$initial_geoip_latitude", "$latitude"),
+            ("$initial_geoip_longitude", "$longitude"),
+            ("$geoip_latitude", "$latitude"),
+            ("$geoip_longitude", "$longitude"),
+        ]:
+            val = user_properties.get(init_key)
+            if val is not None:
+                profile[final_key] = val
+
+        # Don't send near-empty profiles
+        if len(profile[directive]) <= 1:
+            return None
+
+        return profile
+
+    return transform

--- a/src/mixpanel_utils/streaming/vendors/posthog.py
+++ b/src/mixpanel_utils/streaming/vendors/posthog.py
@@ -1,5 +1,7 @@
 """PostHog to Mixpanel vendor transforms."""
 
+from __future__ import annotations
+
 import re
 import json
 from dateutil import parser as dateparser

--- a/src/mixpanel_utils/streaming/vendors/posthog.py
+++ b/src/mixpanel_utils/streaming/vendors/posthog.py
@@ -117,8 +117,7 @@ def posthog_events_to_mp(options: dict, heavy_objects: dict | None = None):
         }
         _add_if_defined(mp_props, "ip", mp_ip)
         _add_if_defined(mp_props, "$city", mp_city)
-        _add_if_defined(mp_props, "$region", mp_country_code)
-        _add_if_defined(mp_props, "mp_country_code", posthog_event.get("country"))
+        _add_if_defined(mp_props, "mp_country_code", mp_country_code)
         _add_if_defined(mp_props, "$insert_id", mp_insert_id)
         _add_if_defined(mp_props, "$latitude", mp_latitude)
         _add_if_defined(mp_props, "$longitude", mp_longitude)

--- a/src/mixpanel_utils/streaming/vendors/posthog.py
+++ b/src/mixpanel_utils/streaming/vendors/posthog.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import re
 import json
-from dateutil import parser as dateparser
 from datetime import datetime, timezone
 
 
@@ -74,6 +73,8 @@ def posthog_events_to_mp(options: dict, heavy_objects: dict | None = None):
     ignore_event_pattern = _build_regex(ignore_events)
 
     def transform(posthog_event: dict) -> dict | None:
+        from dateutil import parser as dateparser
+
         event_name = posthog_event.get("event", "")
         posthog_distinct_id = posthog_event.get("distinct_id")
         mp_ip = posthog_event.get("ip")
@@ -201,6 +202,8 @@ def posthog_person_to_mp_profile(options: dict, heavy_objects: dict | None = Non
     delete_prop_pattern = _build_regex(delete_prefixes)
 
     def transform(posthog_person: dict) -> dict | None:
+        from dateutil import parser as dateparser
+
         distinct_id = posthog_person.get("distinct_id")
         created_at = posthog_person.get("created_at")
         user_properties = posthog_person.get("properties", {}) or {}

--- a/tests/streaming/conftest.py
+++ b/tests/streaming/conftest.py
@@ -1,0 +1,21 @@
+"""Skip all streaming tests when streaming extras are not installed."""
+
+import pytest
+
+try:
+    import mmh3
+    import httpx
+    import dateutil
+    import aiofiles
+
+    HAS_STREAMING = True
+except ImportError:
+    HAS_STREAMING = False
+
+
+def pytest_collection_modifyitems(config, items):
+    if not HAS_STREAMING:
+        skip = pytest.mark.skip(reason="streaming extras not installed")
+        for item in items:
+            if "streaming" in str(item.fspath):
+                item.add_marker(skip)

--- a/tests/streaming/fixtures/amplitude.json
+++ b/tests/streaming/fixtures/amplitude.json
@@ -1,0 +1,1 @@
+{"event_type":"Button Click","device_id":"dev-001","event_time":"2024-01-15T10:30:00Z","user_id":"amp-user-1","ip_address":"1.2.3.4","event_properties":{"button":"signup"},"user_properties":{"plan":"pro"},"$insert_id":"amp-insert-1"}

--- a/tests/streaming/fixtures/events.csv
+++ b/tests/streaming/fixtures/events.csv
@@ -1,0 +1,4 @@
+event,time,$insert_id,page
+PageView,1700000000,c1,/home
+Click,1700000001,c2,/signup
+Purchase,1700000002,c3,/checkout

--- a/tests/streaming/fixtures/events.ndjson
+++ b/tests/streaming/fixtures/events.ndjson
@@ -1,0 +1,3 @@
+{"event":"PageView","properties":{"time":1700000000,"$insert_id":"a1","page":"/home"}}
+{"event":"Click","properties":{"time":1700000001,"$insert_id":"a2","button":"signup"}}
+{"event":"Purchase","properties":{"time":1700000002,"$insert_id":"a3","amount":42}}

--- a/tests/streaming/fixtures/json_dir/batch1.json
+++ b/tests/streaming/fixtures/json_dir/batch1.json
@@ -1,0 +1,4 @@
+[
+  {"event":"A","properties":{"time":1700000000,"$insert_id":"j1"}},
+  {"event":"B","properties":{"time":1700000001,"$insert_id":"j2"}}
+]

--- a/tests/streaming/fixtures/json_dir/batch2.json
+++ b/tests/streaming/fixtures/json_dir/batch2.json
@@ -1,0 +1,3 @@
+[
+  {"event":"C","properties":{"time":1700000002,"$insert_id":"j3"}}
+]

--- a/tests/streaming/fixtures/june_events.csv
+++ b/tests/streaming/fixtures/june_events.csv
@@ -1,0 +1,3 @@
+name,user_id,anonymous_id,timestamp,properties,context,type
+Signup,june-u1,june-a1,2024-01-15T10:30:00Z,"{""plan"":""pro""}","{""ip"":""1.2.3.4""}",track
+Login,june-u1,june-a1,2024-01-15T11:00:00Z,"{""method"":""sso""}","{""ip"":""1.2.3.4""}",track

--- a/tests/streaming/fixtures/mparticle.jsonl
+++ b/tests/streaming/fixtures/mparticle.jsonl
@@ -1,0 +1,1 @@
+{"events":[{"event_type":"custom_event","data":{"event_name":"Purchase","timestamp_unixtime_ms":1700000000000,"custom_attributes":{"product":"Widget"},"event_id":"mp-ev-1"}}],"user_identities":[{"identity_type":"customer_id","identity":"cust-001"}],"mpid":"mp-123","batch_id":"batch-1"}

--- a/tests/streaming/test_bug_fixes.py
+++ b/tests/streaming/test_bug_fixes.py
@@ -1,0 +1,190 @@
+"""Tests for bug fixes documented in improvements.md."""
+
+import asyncio
+import gzip
+import json
+import os
+import tempfile
+import pytest
+from pathlib import Path
+
+from mixpanel_utils.streaming import mp_import
+from mixpanel_utils.streaming.transforms.builtin import ez_transforms
+from mixpanel_utils.streaming.core.job import Job
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+class FakeJob:
+    """Minimal job stub for testing transforms."""
+    def __init__(self, **kwargs):
+        self.record_type = kwargs.get("record_type", "event")
+        self.token = kwargs.get("token", "test-token")
+        self.tags = kwargs.get("tags", {})
+        self.aliases = kwargs.get("aliases", {})
+        self.directive = kwargs.get("directive", "$set")
+        self.group_key = kwargs.get("group_key", "")
+
+
+# ── BUG-3: Group $group_key preservation ────────────────────────────
+
+class TestGroupTransformFix:
+    def test_preserves_preshaped_group(self):
+        """Pre-shaped records with $group_key/$group_id/$set should survive."""
+        job = FakeJob(record_type="group", group_key="company")
+        transform = ez_transforms(job)
+        record = {
+            "$group_key": "company",
+            "$group_id": "Acme Corp",
+            "$set": {"industry": "Tech", "employees": 500},
+        }
+        result = transform(record)
+        assert result["$group_key"] == "company"
+        assert result["$group_id"] == "Acme Corp"
+        assert result["$set"]["industry"] == "Tech"
+        assert result["$token"] == "test-token"
+
+    def test_reshapes_flat_group(self):
+        """Flat group records should still be correctly reshaped."""
+        job = FakeJob(record_type="group", group_key="company")
+        transform = ez_transforms(job)
+        record = {
+            "$group_id": "Acme Corp",
+            "industry": "Tech",
+            "employees": 500,
+        }
+        result = transform(record)
+        assert result["$group_id"] == "Acme Corp"
+        assert "$set" in result
+        assert result["$set"]["industry"] == "Tech"
+        assert result["$token"] == "test-token"
+
+    def test_group_dry_run_pipeline(self):
+        """Group records should pass through the full pipeline."""
+        records = [
+            {
+                "$group_key": "company",
+                "$group_id": "Acme",
+                "$set": {"plan": "enterprise"},
+            },
+        ]
+        result = run(mp_import(None, records, {
+            "record_type": "group",
+            "dry_run": True,
+            "fix_data": True,
+            "group_key": "company",
+        }))
+        assert result["success"] == 1
+        rec = result["dry_run"][0]
+        assert rec["$group_key"] == "company"
+        assert rec["$group_id"] == "Acme"
+
+
+# ── BUG-5: Failed records error messages ────────────────────────────
+
+class TestStoreFailedRecords:
+    def test_failed_records_show_real_errors(self):
+        """job.store() with failed_records should show real error messages."""
+        job = Job({"token": "test"}, {"dry_run": True})
+        run(job.init())
+
+        response = {
+            "num_records_imported": 0,
+            "num_failed": 2,
+            "failed_records": [
+                {"index": 0, "message": "event name is empty"},
+                {"index": 1, "message": "invalid property type"},
+            ],
+            "error": None,
+            "status": 0,
+        }
+        job.store(response, success=False)
+
+        assert "event name is empty" in job.errors
+        assert "invalid property type" in job.errors
+        assert "unknown error" not in job.errors
+
+    def test_error_field_preserved(self):
+        """job.store() with error field should show the error."""
+        job = Job({"token": "test"}, {"dry_run": True})
+        run(job.init())
+
+        response = {
+            "error": "Unauthorized, invalid project secret",
+            "status": 0,
+        }
+        job.store(response, success=False)
+
+        assert "Unauthorized, invalid project secret" in job.errors
+
+
+# ── BUG-6: Profile double-counting ──────────────────────────────────
+
+class TestProfileCounting:
+    def test_no_double_count_on_error_with_status(self):
+        """User profiles should not double-count success+failure."""
+        profiles = [
+            {"$distinct_id": "u1", "$set": {"name": "Alice"}},
+            {"$distinct_id": "u2", "$set": {"name": "Bob"}},
+        ]
+        result = run(mp_import(None, profiles, {
+            "record_type": "user",
+            "dry_run": True,
+        }))
+        # In dry_run, all should succeed with no double-counting
+        assert result["success"] == 2
+        assert result["failed"] == 0
+
+
+# ── BUG-8: Parquet null stripping ───────────────────────────────────
+
+class TestParquetNulls:
+    def test_parquet_nulls_stripped(self):
+        """Parquet reader should auto-strip None values."""
+        try:
+            import pyarrow as pa
+            import pyarrow.parquet as pq
+        except ImportError:
+            pytest.skip("pyarrow not installed")
+
+        # Create a parquet file with null values
+        table = pa.table({
+            "event": ["Click", "View", "Buy"],
+            "user": ["u1", None, "u3"],
+            "value": [1, 2, None],
+        })
+        with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
+            pq.write_table(table, f.name)
+            parquet_path = f.name
+
+        try:
+            result = run(mp_import(None, parquet_path, {"dry_run": True}))
+            assert result["total"] == 3
+            for rec in result["dry_run"]:
+                # No record should have None values in any field
+                for k, v in rec.items():
+                    if isinstance(v, dict):
+                        for ik, iv in v.items():
+                            assert iv is not None, f"Null found in {k}.{ik}"
+                    else:
+                        assert v is not None, f"Null found in {k}"
+        finally:
+            os.unlink(parquet_path)
+
+
+# ── BUG-1: Cloud stream async generator ─────────────────────────────
+
+class TestCloudStreamType:
+    def test_gcs_stream_is_async_generator(self):
+        """_gcs_stream should return an async generator, not a coroutine."""
+        from mixpanel_utils.streaming.io.parsers import _gcs_stream
+        import inspect
+        assert inspect.isasyncgenfunction(_gcs_stream)
+
+    def test_s3_stream_is_async_generator(self):
+        """_s3_stream should return an async generator, not a coroutine."""
+        from mixpanel_utils.streaming.io.parsers import _s3_stream
+        import inspect
+        assert inspect.isasyncgenfunction(_s3_stream)

--- a/tests/streaming/test_job.py
+++ b/tests/streaming/test_job.py
@@ -1,0 +1,95 @@
+"""Tests for the Job configuration class."""
+
+import pytest
+from mixpanel_utils.streaming.core.job import Job
+
+
+class TestJobConfig:
+    def test_default_config(self):
+        job = Job({"token": "test"}, {})
+        assert job.record_type == "event"
+        assert job.region == "US"
+        assert job.workers == 10
+        assert job.records_per_batch == 2000
+        assert job.compress is True
+        assert job.strict is True
+        assert job.verbose is False
+
+    def test_write_to_file_allows_empty_creds(self):
+        job = Job(None, {"write_to_file": True})
+        assert job.write_to_file is True
+        assert job.auth == ""
+
+    def test_dry_run_allows_empty_creds(self):
+        job = Job(None, {"dry_run": True})
+        assert job.dry_run is True
+        assert job.auth == ""
+
+    def test_token_auth(self):
+        job = Job({"token": "abc123"}, {})
+        assert "Basic" in job.auth
+
+    def test_service_account_auth(self):
+        job = Job({"acct": "user", "pass": "pw", "project": "123"}, {})
+        assert "Basic" in job.auth
+
+    def test_secret_auth(self):
+        job = Job({"secret": "mysecret"}, {})
+        assert "Basic" in job.auth
+
+    def test_no_creds_raises(self):
+        with pytest.raises(ValueError, match="No credentials"):
+            Job(None, {})
+
+    def test_custom_options(self):
+        job = Job({"token": "t"}, {
+            "workers": 20,
+            "records_per_batch": 500,
+            "compress": False,
+            "fix_data": True,
+            "dedupe": True,
+            "region": "EU",
+        })
+        assert job.workers == 20
+        assert job.records_per_batch == 500
+        assert job.compress is False
+        assert job.fix_data is True
+        assert job.dedupe is True
+        assert job.region == "EU"
+
+    def test_transform_ordering(self):
+        job = Job({"token": "t"}, {
+            "fix_data": True,
+            "aliases": {"old": "new"},
+            "tags": {"env": "test"},
+            "remove_nulls": True,
+        })
+        # Should have at least aliases, ez_transforms, tags, remove_nulls
+        assert len(job.active_transforms) >= 4
+
+    def test_dimension_maps_config(self):
+        job = Job({"token": "t"}, {
+            "dimension_maps": [
+                {"filePath": "test.json", "keyOne": "a", "keyTwo": "b", "label": "test"}
+            ]
+        })
+        assert len(job.dimension_maps) == 1
+        assert job.dimension_maps[0]["label"] == "test"
+
+    def test_progress_callback_config(self):
+        def my_callback(job):
+            pass
+
+        job = Job({"token": "t"}, {"progress_callback": my_callback})
+        assert job.progress_callback is my_callback
+
+    def test_camel_case_options(self):
+        """Verify camelCase option names work (for JS compatibility)."""
+        job = Job({"token": "t"}, {
+            "recordType": "user",
+            "fixData": True,
+            "vendorOpts": {"key": "val"},
+        })
+        assert job.record_type == "user"
+        assert job.fix_data is True
+        assert job.vendor_opts == {"key": "val"}

--- a/tests/streaming/test_pipeline.py
+++ b/tests/streaming/test_pipeline.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from mixpanel_utils.streaming import mp_import
 
-TEST_DATA = Path(__file__).parent.parent.parent / "SCRATCH_TEST_DATA"
+FIXTURES = Path(__file__).parent / "fixtures"
 
 
 @pytest.fixture
@@ -25,21 +25,17 @@ def run(coro):
 
 class TestDryRun:
     def test_jsonl_dry_run(self):
-        path = TEST_DATA / "events.ndjson"
-        if not path.exists():
-            pytest.skip("Test data not available")
+        path = FIXTURES / "events.ndjson"
         result = run(mp_import(None, str(path), {"dry_run": True}))
-        assert result["total"] > 0
-        assert result["success"] == result["total"]
-        assert len(result["dry_run"]) == result["total"]
+        assert result["total"] == 3
+        assert result["success"] == 3
+        assert len(result["dry_run"]) == 3
 
     def test_csv_dry_run(self):
-        path = TEST_DATA / "eventAsTable.csv"
-        if not path.exists():
-            pytest.skip("Test data not available")
+        path = FIXTURES / "events.csv"
         result = run(mp_import(None, str(path), {"dry_run": True, "stream_format": "csv"}))
-        assert result["total"] > 0
-        assert result["success"] > 0
+        assert result["total"] == 3
+        assert result["success"] == 3
 
     def test_list_input(self):
         events = [
@@ -107,52 +103,44 @@ class TestDryRun:
 
 class TestVendorDryRun:
     def test_amplitude_vendor(self):
-        path = TEST_DATA / "amplitude" / "2023-04-10_1#0.json"
-        if not path.exists():
-            pytest.skip("Test data not available")
+        path = FIXTURES / "amplitude.json"
         result = run(mp_import(None, str(path), {
             "vendor": "amplitude",
             "vendor_opts": {"user_id": "user_id", "v2_compat": True},
             "dry_run": True,
             "fix_data": True,
         }))
-        assert result["total"] > 0
-        assert result["success"] == result["total"]
+        assert result["total"] == 1
+        assert result["success"] == 1
         assert result["dry_run"][0]["properties"]["$source"] == "amplitude-to-mixpanel"
 
     def test_june_csv_vendor(self):
-        path = TEST_DATA / "june" / "events-small.csv"
-        if not path.exists():
-            pytest.skip("Test data not available")
+        path = FIXTURES / "june_events.csv"
         result = run(mp_import(None, str(path), {
             "vendor": "june",
             "vendor_opts": {"v2compat": True},
             "dry_run": True,
             "stream_format": "csv",
         }))
-        assert result["total"] > 0
-        assert result["success"] == result["total"]
+        assert result["total"] == 2
+        assert result["success"] == 2
 
     def test_mparticle_vendor(self):
-        path = TEST_DATA / "mparticle" / "sample_data.txt"
-        if not path.exists():
-            pytest.skip("Test data not available")
+        path = FIXTURES / "mparticle.jsonl"
         result = run(mp_import(None, str(path), {
             "vendor": "mparticle",
             "dry_run": True,
             "stream_format": "jsonl",
         }))
-        assert result["total"] > 0
-        assert result["success"] > 0
+        assert result["total"] == 1
+        assert result["success"] == 1
 
 
 class TestDirectoryImport:
     def test_directory_import(self):
-        path = TEST_DATA / "formats" / "json"
-        if not path.exists() or not path.is_dir():
-            pytest.skip("Test data not available")
+        path = FIXTURES / "json_dir"
         result = run(mp_import(None, str(path), {"dry_run": True}))
-        assert result["total"] > 0
+        assert result["total"] == 3
 
 
 class TestWriteToFile:

--- a/tests/streaming/test_pipeline.py
+++ b/tests/streaming/test_pipeline.py
@@ -1,0 +1,235 @@
+"""Tests for the async pipeline and dry-run mode."""
+
+import asyncio
+import json
+import os
+import tempfile
+import pytest
+from pathlib import Path
+
+from mixpanel_utils.streaming import mp_import
+
+TEST_DATA = Path(__file__).parent.parent.parent / "SCRATCH_TEST_DATA"
+
+
+@pytest.fixture
+def event_loop():
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+class TestDryRun:
+    def test_jsonl_dry_run(self):
+        path = TEST_DATA / "events.ndjson"
+        if not path.exists():
+            pytest.skip("Test data not available")
+        result = run(mp_import(None, str(path), {"dry_run": True}))
+        assert result["total"] > 0
+        assert result["success"] == result["total"]
+        assert len(result["dry_run"]) == result["total"]
+
+    def test_csv_dry_run(self):
+        path = TEST_DATA / "eventAsTable.csv"
+        if not path.exists():
+            pytest.skip("Test data not available")
+        result = run(mp_import(None, str(path), {"dry_run": True, "stream_format": "csv"}))
+        assert result["total"] > 0
+        assert result["success"] > 0
+
+    def test_list_input(self):
+        events = [
+            {"event": "Test", "properties": {"time": 1700000000, "$insert_id": "a"}},
+            {"event": "Test2", "properties": {"time": 1700000001, "$insert_id": "b"}},
+        ]
+        result = run(mp_import(None, events, {"dry_run": True}))
+        assert result["total"] == 2
+        assert result["success"] == 2
+
+    def test_inline_json(self):
+        data = '[{"event":"A","properties":{"time":1700000000}},{"event":"B","properties":{"time":1700000001}}]'
+        result = run(mp_import(None, data, {"dry_run": True}))
+        assert result["total"] == 2
+
+    def test_fix_data_mode(self):
+        events = [
+            {"event": "Test", "page": "/home", "time": "2024-01-15"},
+        ]
+        result = run(mp_import(None, events, {"dry_run": True, "fix_data": True}))
+        assert result["total"] == 1
+        assert result["success"] == 1
+        # fixData should have moved props into properties and fixed time
+        evt = result["dry_run"][0]
+        assert "properties" in evt
+
+    def test_user_profile_dry_run(self):
+        profiles = [
+            {"$distinct_id": "u1", "$set": {"name": "Alice"}},
+            {"$distinct_id": "u2", "$set": {"name": "Bob"}},
+        ]
+        result = run(mp_import(None, profiles, {"record_type": "user", "dry_run": True}))
+        assert result["total"] == 2
+        assert result["success"] == 2
+
+    def test_dedupe(self):
+        events = [
+            {"event": "Dup", "properties": {"key": "val", "time": 1}},
+            {"event": "Dup", "properties": {"key": "val", "time": 1}},
+            {"event": "Unique", "properties": {"key": "other", "time": 2}},
+        ]
+        result = run(mp_import(None, events, {"dry_run": True, "dedupe": True}))
+        assert result["total"] == 3
+        assert result["duplicates"] == 1
+        assert result["success"] == 2
+
+    def test_transform_func(self):
+        events = [
+            {"event": "Raw", "properties": {"time": 1700000000}},
+        ]
+
+        def my_transform(record):
+            record["event"] = "Transformed"
+            return record
+
+        result = run(mp_import(None, events, {"dry_run": True, "transform_func": my_transform}))
+        assert result["success"] == 1
+        assert result["dry_run"][0]["event"] == "Transformed"
+
+    def test_max_records(self):
+        events = [{"event": f"E{i}", "properties": {"time": i}} for i in range(100)]
+        result = run(mp_import(None, events, {"dry_run": True, "max_records": 10}))
+        assert result["total"] == 10
+
+
+class TestVendorDryRun:
+    def test_amplitude_vendor(self):
+        path = TEST_DATA / "amplitude" / "2023-04-10_1#0.json"
+        if not path.exists():
+            pytest.skip("Test data not available")
+        result = run(mp_import(None, str(path), {
+            "vendor": "amplitude",
+            "vendor_opts": {"user_id": "user_id", "v2_compat": True},
+            "dry_run": True,
+            "fix_data": True,
+        }))
+        assert result["total"] > 0
+        assert result["success"] == result["total"]
+        assert result["dry_run"][0]["properties"]["$source"] == "amplitude-to-mixpanel"
+
+    def test_june_csv_vendor(self):
+        path = TEST_DATA / "june" / "events-small.csv"
+        if not path.exists():
+            pytest.skip("Test data not available")
+        result = run(mp_import(None, str(path), {
+            "vendor": "june",
+            "vendor_opts": {"v2compat": True},
+            "dry_run": True,
+            "stream_format": "csv",
+        }))
+        assert result["total"] > 0
+        assert result["success"] == result["total"]
+
+    def test_mparticle_vendor(self):
+        path = TEST_DATA / "mparticle" / "sample_data.txt"
+        if not path.exists():
+            pytest.skip("Test data not available")
+        result = run(mp_import(None, str(path), {
+            "vendor": "mparticle",
+            "dry_run": True,
+            "stream_format": "jsonl",
+        }))
+        assert result["total"] > 0
+        assert result["success"] > 0
+
+
+class TestDirectoryImport:
+    def test_directory_import(self):
+        path = TEST_DATA / "formats" / "json"
+        if not path.exists() or not path.is_dir():
+            pytest.skip("Test data not available")
+        result = run(mp_import(None, str(path), {"dry_run": True}))
+        assert result["total"] > 0
+
+
+class TestWriteToFile:
+    def test_write_to_file_creates_ndjson(self):
+        events = [
+            {"event": "A", "properties": {"time": 1700000000}},
+            {"event": "B", "properties": {"time": 1700000001}},
+        ]
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w") as f:
+            out_path = f.name
+
+        try:
+            result = run(mp_import(None, events, {
+                "write_to_file": True,
+                "output_file_path": out_path,
+            }))
+            assert result["success"] == 2
+            with open(out_path) as f:
+                lines = [json.loads(line) for line in f if line.strip()]
+            assert len(lines) == 2
+            assert lines[0]["event"] == "A"
+            assert lines[1]["event"] == "B"
+        finally:
+            os.unlink(out_path)
+
+    def test_write_to_file_no_creds_required(self):
+        events = [{"event": "Test", "properties": {"time": 1}}]
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w") as f:
+            out_path = f.name
+
+        try:
+            result = run(mp_import(None, events, {
+                "write_to_file": True,
+                "output_file_path": out_path,
+            }))
+            assert result["success"] == 1
+        finally:
+            os.unlink(out_path)
+
+    def test_write_to_file_with_transforms(self):
+        events = [{"event": "Raw", "page": "/home", "time": "2024-01-15"}]
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w") as f:
+            out_path = f.name
+
+        try:
+            result = run(mp_import(None, events, {
+                "write_to_file": True,
+                "output_file_path": out_path,
+                "fix_data": True,
+            }))
+            assert result["success"] == 1
+            with open(out_path) as f:
+                lines = [json.loads(line) for line in f if line.strip()]
+            assert len(lines) == 1
+            assert "properties" in lines[0]
+        finally:
+            os.unlink(out_path)
+
+
+class TestHeavyObjects:
+    def test_dimension_map_loading(self):
+        map_data = [
+            {"posthog_id": "ph1", "mp_id": "mp1"},
+            {"posthog_id": "ph2", "mp_id": "mp2"},
+        ]
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w") as f:
+            json.dump(map_data, f)
+            map_path = f.name
+
+        try:
+            events = [{"event": "Test", "properties": {"time": 1}}]
+            result = run(mp_import(None, events, {
+                "dry_run": True,
+                "dimension_maps": [
+                    {"filePath": map_path, "keyOne": "posthog_id", "keyTwo": "mp_id", "label": "people"}
+                ],
+            }))
+            assert result["success"] == 1
+        finally:
+            os.unlink(map_path)

--- a/tests/streaming/test_transforms.py
+++ b/tests/streaming/test_transforms.py
@@ -1,0 +1,229 @@
+"""Tests for built-in transforms, vendor transforms, dedup, and filters."""
+
+import pytest
+from mixpanel_utils.streaming.transforms.builtin import (
+    ez_transforms, apply_aliases, add_tags, add_token,
+    remove_nulls, flatten_properties, utc_offset,
+    fix_time, fix_json, scrub_properties, add_insert,
+)
+from mixpanel_utils.streaming.transforms.dedup import dedupe_records
+from mixpanel_utils.streaming.transforms.filters import whitelist_blacklist, epoch_filter
+
+
+class FakeJob:
+    """Minimal job stub for testing transforms."""
+
+    def __init__(self, **kwargs):
+        self.record_type = kwargs.get("record_type", "event")
+        self.token = kwargs.get("token", "test-token")
+        self.tags = kwargs.get("tags", {})
+        self.aliases = kwargs.get("aliases", {})
+        self.directive = kwargs.get("directive", "$set")
+        self.epoch_start = kwargs.get("epoch_start", 0)
+        self.epoch_end = kwargs.get("epoch_end", 9991427224)
+        self.out_of_bounds = 0
+        self.whitelist_skipped = 0
+        self.blacklist_skipped = 0
+        self.duplicates = 0
+        self.hash_table = set()
+        self.insert_id_tuple = kwargs.get("insert_id_tuple", [])
+
+
+# ── ez_transforms ───────────────────────────────────────────────────
+
+class TestEzTransforms:
+    def test_event_basic(self):
+        job = FakeJob(record_type="event", token="tok123")
+        transform = ez_transforms(job)
+        record = {"event": "Page View", "properties": {"page": "/home"}}
+        result = transform(record)
+        assert result["event"] == "Page View"
+        assert result["properties"]["page"] == "/home"
+        assert "$insert_id" in result["properties"]
+
+    def test_event_name_from_event_name_key(self):
+        job = FakeJob(record_type="event")
+        transform = ez_transforms(job)
+        record = {"event_name": "Click", "properties": {}}
+        result = transform(record)
+        assert result["event"] == "Click"
+
+    def test_user_profile_set(self):
+        job = FakeJob(record_type="user", token="tok123")
+        transform = ez_transforms(job)
+        record = {"$distinct_id": "user1", "$set": {"name": "Alice"}}
+        result = transform(record)
+        assert result["$distinct_id"] == "user1"
+        # ez_transforms renames "name" to "$name" (Mixpanel special prop)
+        assert result["$set"].get("$name") == "Alice" or result["$set"].get("name") == "Alice"
+
+    def test_user_profile_bare_props(self):
+        job = FakeJob(record_type="user", token="tok123")
+        transform = ez_transforms(job)
+        record = {"$distinct_id": "user1", "name": "Bob", "plan": "pro"}
+        result = transform(record)
+        assert result.get("$distinct_id") == "user1"
+        # Props should be in a $set bucket; name may be renamed to $name
+        set_props = result.get("$set", {})
+        assert set_props.get("$name") == "Bob" or set_props.get("name") == "Bob"
+        assert "plan" in set_props
+
+    def test_skip_empty_event(self):
+        job = FakeJob(record_type="event")
+        transform = ez_transforms(job)
+        result = transform({})
+        # Empty events may still return a dict with just event="" and minimal props
+        assert result == {} or result is None or (isinstance(result, dict) and not result.get("event"))
+
+
+# ── apply_aliases ───────────────────────────────────────────────────
+
+class TestAliases:
+    def test_rename_event_props(self):
+        job = FakeJob(aliases={"old_name": "new_name"})
+        transform = apply_aliases(job)
+        record = {"event": "Test", "properties": {"old_name": "value"}}
+        result = transform(record)
+        assert "new_name" in result["properties"]
+        assert "old_name" not in result["properties"]
+
+
+# ── add_tags ────────────────────────────────────────────────────────
+
+class TestTags:
+    def test_add_tags_to_event(self):
+        job = FakeJob(tags={"env": "test", "version": "1.0"})
+        transform = add_tags(job)
+        record = {"event": "Test", "properties": {"page": "/home"}}
+        result = transform(record)
+        assert result["properties"]["env"] == "test"
+        assert result["properties"]["version"] == "1.0"
+
+
+# ── remove_nulls ────────────────────────────────────────────────────
+
+class TestRemoveNulls:
+    def test_removes_none_values(self):
+        transform = remove_nulls()
+        record = {"event": "Test", "properties": {"a": 1, "b": None, "c": ""}}
+        result = transform(record)
+        assert "b" not in result["properties"]
+        assert "c" not in result["properties"]
+        assert result["properties"]["a"] == 1
+
+
+# ── flatten_properties ──────────────────────────────────────────────
+
+class TestFlatten:
+    def test_flattens_nested_dict(self):
+        transform = flatten_properties()
+        record = {"event": "Test", "properties": {"user": {"name": "Alice", "age": 30}}}
+        result = transform(record)
+        assert result["properties"]["user.name"] == "Alice"
+        assert result["properties"]["user.age"] == 30
+
+
+# ── fix_json ────────────────────────────────────────────────────────
+
+class TestFixJson:
+    def test_parses_json_strings(self):
+        transform = fix_json()
+        record = {"event": "Test", "properties": {"data": '{"key": "value"}'}}
+        result = transform(record)
+        assert result["properties"]["data"] == {"key": "value"}
+
+
+# ── scrub_properties ───────────────────────────────────────────────
+
+class TestScrub:
+    def test_removes_specified_props(self):
+        transform = scrub_properties(["secret", "internal"])
+        record = {"event": "Test", "properties": {"secret": "123", "page": "/home", "internal": True}}
+        result = transform(record)
+        assert "secret" not in result["properties"]
+        assert "internal" not in result["properties"]
+        assert result["properties"]["page"] == "/home"
+
+
+# ── dedup ───────────────────────────────────────────────────────────
+
+class TestDedup:
+    def test_deduplicates(self):
+        job = FakeJob()
+        transform = dedupe_records(job)
+        r1 = {"event": "Test", "properties": {"key": "val"}}
+        r2 = {"event": "Test", "properties": {"key": "val"}}
+        r3 = {"event": "Other", "properties": {"key": "val"}}
+
+        result1 = transform(r1)
+        assert result1 is not None and result1 != {}
+        result2 = transform(r2)
+        assert result2 is None or result2 == {}  # duplicate
+        result3 = transform(r3)
+        assert result3 is not None and result3 != {}
+        assert job.duplicates == 1
+
+
+# ── epoch_filter ────────────────────────────────────────────────────
+
+class TestEpochFilter:
+    def test_filters_by_epoch(self):
+        job = FakeJob(epoch_start=1000, epoch_end=2000)
+        transform = epoch_filter(job)
+
+        in_range = {"event": "Test", "properties": {"time": 1500}}
+        too_early = {"event": "Test", "properties": {"time": 500}}
+        too_late = {"event": "Test", "properties": {"time": 3000}}
+
+        assert transform(in_range) is not None
+        assert transform(too_early) is None
+        assert transform(too_late) is None
+        assert job.out_of_bounds == 2
+
+
+# ── whitelist_blacklist ─────────────────────────────────────────────
+
+class TestWhitelistBlacklist:
+    def test_event_whitelist(self):
+        job = FakeJob()
+        params = {
+            "event_whitelist": ["Page View", "Sign Up"],
+            "event_blacklist": [],
+            "prop_key_whitelist": [],
+            "prop_key_blacklist": [],
+            "prop_val_whitelist": [],
+            "prop_val_blacklist": [],
+            "combo_white_list": {},
+            "combo_black_list": {},
+        }
+        transform = whitelist_blacklist(job, params)
+
+        allowed = {"event": "Page View", "properties": {}}
+        blocked = {"event": "Random Event", "properties": {}}
+
+        result_allowed = transform(allowed)
+        assert result_allowed is not None and result_allowed != {}
+        result_blocked = transform(blocked)
+        assert result_blocked is None or result_blocked == {}
+
+    def test_event_blacklist(self):
+        job = FakeJob()
+        params = {
+            "event_whitelist": [],
+            "event_blacklist": ["Spam Event"],
+            "prop_key_whitelist": [],
+            "prop_key_blacklist": [],
+            "prop_val_whitelist": [],
+            "prop_val_blacklist": [],
+            "combo_white_list": {},
+            "combo_black_list": {},
+        }
+        transform = whitelist_blacklist(job, params)
+
+        allowed = {"event": "Page View", "properties": {}}
+        blocked = {"event": "Spam Event", "properties": {}}
+
+        result_allowed = transform(allowed)
+        assert result_allowed is not None and result_allowed != {}
+        result_blocked = transform(blocked)
+        assert result_blocked is None or result_blocked == {}

--- a/tests/streaming/test_vendors.py
+++ b/tests/streaming/test_vendors.py
@@ -1,0 +1,295 @@
+"""Tests for vendor-specific transforms."""
+
+import json
+import pytest
+from pathlib import Path
+
+from mixpanel_utils.streaming.vendors.amplitude import amp_events_to_mp, amp_user_to_mp, amp_group_to_mp
+from mixpanel_utils.streaming.vendors.heap import heap_events_to_mp, heap_user_to_mp
+from mixpanel_utils.streaming.vendors.ga4 import ga_events_to_mp, ga_user_to_mp, ga_groups_to_mp
+from mixpanel_utils.streaming.vendors.posthog import posthog_events_to_mp, posthog_person_to_mp_profile
+from mixpanel_utils.streaming.vendors.mparticle import mparticle_events_to_mixpanel, mparticle_user_to_mixpanel
+from mixpanel_utils.streaming.vendors.june import june_events_to_mp, june_user_to_mp, june_group_to_mp
+from mixpanel_utils.streaming.vendors.mixpanel import mixpanel_events_to_mixpanel
+
+TEST_DATA = Path(__file__).parent.parent.parent / "SCRATCH_TEST_DATA"
+
+
+class TestAmplitude:
+    def test_event_transform(self):
+        transform = amp_events_to_mp({"user_id": "user_id", "v2_compat": True})
+        record = {
+            "event_type": "Button Click",
+            "device_id": "dev123",
+            "event_time": "2024-01-15T10:30:00Z",
+            "user_id": "user456",
+            "ip_address": "1.2.3.4",
+            "event_properties": {"button": "signup"},
+            "user_properties": {"plan": "pro"},
+        }
+        result = transform(record)
+        assert result["event"] == "Button Click"
+        assert result["properties"]["$user_id"] == "user456"
+        assert result["properties"]["$source"] == "amplitude-to-mixpanel"
+        assert result["properties"]["button"] == "signup"
+        assert result["properties"]["distinct_id"] == "user456"
+
+    def test_skips_experiment_events(self):
+        transform = amp_events_to_mp({"includeExperimentEvents": False})
+        record = {
+            "event_type": "[Experiment] test variant",
+            "device_id": "dev1",
+            "event_time": "2024-01-15T10:00:00Z",
+        }
+        assert transform(record) is None
+
+    def test_user_transform(self):
+        transform = amp_user_to_mp({"user_id": "user_id"})
+        record = {
+            "user_id": "user789",
+            "user_properties": {"name": "Alice", "plan": "enterprise"},
+            "ip_address": "5.6.7.8",
+        }
+        result = transform(record)
+        assert result["$distinct_id"] == "user789"
+        assert result["$set"]["name"] == "Alice"
+
+    def test_user_skip_empty(self):
+        transform = amp_user_to_mp({"user_id": "user_id"})
+        result = transform({"user_properties": {}})
+        assert result == {}
+
+    def test_real_data(self):
+        path = TEST_DATA / "amplitude" / "2023-04-10_1#0.json"
+        if not path.exists():
+            pytest.skip("Test data not available")
+        transform = amp_events_to_mp({"user_id": "user_id", "v2_compat": True})
+        with open(path) as f:
+            record = json.loads(f.readline())
+        result = transform(record)
+        assert result is not None
+        assert result["event"]
+        assert "$insert_id" in result["properties"]
+
+
+class TestHeap:
+    def test_event_transform(self):
+        transform = heap_events_to_mp({})
+        record = {
+            "type": "pageview",
+            "id": "(123,456789)",
+            "time": "2024-01-15T10:00:00Z",
+            "properties": {"page": "/home"},
+        }
+        result = transform(record)
+        assert result["event"] == "pageview"
+        assert result["properties"]["$device_id"] == "456789"
+        assert result["properties"]["$source"] == "heap-to-mixpanel"
+
+    def test_user_transform(self):
+        transform = heap_user_to_mp({})
+        record = {
+            "id": "(123,456789)",
+            "identity": "user@example.com",
+            "properties": {"name": "Bob"},
+        }
+        result = transform(record)
+        assert result["$distinct_id"] == "user@example.com"
+
+    def test_real_data(self):
+        path = TEST_DATA / "heap" / "heap-events-ex.json"
+        if not path.exists():
+            pytest.skip("Test data not available")
+        transform = heap_events_to_mp({})
+        data = _load_json_or_jsonl(path)
+        result = transform(data[0])
+        assert result is not None
+        assert result.get("event")
+
+
+class TestGA4:
+    def test_event_transform(self):
+        transform = ga_events_to_mp({"time_conversion": "seconds"})
+        record = {
+            "event_name": "page_view",
+            "user_pseudo_id": "pseudo123",
+            "event_timestamp": "1695676578000000",
+            "event_params": [
+                {"key": "page_title", "value": {"string_value": "Home"}},
+                {"key": "engagement_time", "value": {"int_value": 5000}},
+            ],
+        }
+        result = transform(record)
+        assert result["event"] == "page_view"
+        assert result["properties"]["time"] == 1695676578
+        assert result["properties"]["$source"] == "ga4-to-mixpanel"
+        assert result["properties"]["page_title"] == "Home"
+
+    def test_insert_id_generation(self):
+        transform = ga_events_to_mp({"set_insert_id": True})
+        record = {
+            "event_name": "click",
+            "user_pseudo_id": "user1",
+            "event_bundle_sequence_id": "123",
+            "event_timestamp": "1695676578000000",
+            "event_params": [],
+        }
+        result = transform(record)
+        assert "$insert_id" in result["properties"]
+
+    def test_real_data(self):
+        path = TEST_DATA / "ga4" / "ga4_sample.json"
+        if not path.exists():
+            pytest.skip("Test data not available")
+        transform = ga_events_to_mp({"time_conversion": "seconds"})
+        data = _load_json_or_jsonl(path)
+        result = transform(data[0])
+        assert result is not None
+        assert result.get("event")
+
+
+class TestPostHog:
+    def test_event_transform(self):
+        transform = posthog_events_to_mp({})
+        record = {
+            "event": "page_view",
+            "distinct_id": "user1",
+            "timestamp": "2024-01-15T10:00:00Z",
+            "uuid": "uuid-123",
+            "properties": {
+                "$device_id": "device1",
+                "$user_id": "user1",
+                "page": "/home",
+            },
+        }
+        result = transform(record)
+        assert result["event"] == "page_view"
+        assert result["properties"]["$source"] == "posthog-to-mixpanel"
+
+    def test_filters_system_events(self):
+        transform = posthog_events_to_mp({})
+        record = {"event": "$feature", "distinct_id": "u1", "timestamp": "2024-01-01", "properties": {}}
+        assert transform(record) is None
+
+        record2 = {"event": "$set", "distinct_id": "u1", "timestamp": "2024-01-01", "properties": {}}
+        assert transform(record2) is None
+
+    def test_person_profile(self):
+        transform = posthog_person_to_mp_profile({})
+        record = {
+            "distinct_id": "user1",
+            "created_at": "2024-01-01T00:00:00Z",
+            "properties": {
+                "email": "test@test.com",
+                "name": "Test User",
+                "$os": "Mac OS X",
+            },
+        }
+        result = transform(record)
+        assert result["$distinct_id"] == "user1"
+        assert result["$set"]["$email"] == "test@test.com"
+
+
+class TestMParticle:
+    def test_batch_event_transform(self):
+        transform = mparticle_events_to_mixpanel({})
+        batch = {
+            "events": [
+                {
+                    "event_type": "custom_event",
+                    "data": {
+                        "event_name": "Purchase",
+                        "timestamp_unixtime_ms": 1700000000000,
+                        "custom_attributes": {"product": "Widget"},
+                    },
+                }
+            ],
+            "user_identities": [
+                {"identity_type": "customer_id", "identity": "cust123"}
+            ],
+            "mpid": "mp-123",
+        }
+        result = transform(batch)
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["event"] == "Purchase"
+        assert result[0]["properties"]["$user_id"] == "cust123"
+
+    def test_real_data(self):
+        path = TEST_DATA / "mparticle" / "sample_data.txt"
+        if not path.exists():
+            pytest.skip("Test data not available")
+        transform = mparticle_events_to_mixpanel({})
+        data = _load_json_or_jsonl(path)
+        result = transform(data[0])
+        assert isinstance(result, list)
+
+
+class TestJune:
+    def test_event_transform(self):
+        transform = june_events_to_mp({"v2compat": True})
+        record = {
+            "name": "Signup",
+            "user_id": "u1",
+            "anonymous_id": "a1",
+            "timestamp": "2024-01-15T10:30:00Z",
+            "properties": '{"plan": "pro"}',
+            "context": '{"ip": "1.2.3.4"}',
+            "type": "track",
+        }
+        result = transform(record)
+        assert result["event"] == "Signup"
+        assert result["properties"]["$user_id"] == "u1"
+        assert result["properties"]["$device_id"] == "a1"
+        assert result["properties"]["distinct_id"] == "u1"
+        assert result["properties"]["plan"] == "pro"
+
+    def test_user_transform(self):
+        transform = june_user_to_mp({})
+        record = {
+            "user_id": "u1",
+            "traits": '{"email": "test@test.com", "name": "Test"}',
+            "context": "{}",
+        }
+        result = transform(record)
+        assert result["$distinct_id"] == "u1"
+        assert result["$set"]["$email"] == "test@test.com"
+
+    def test_group_transform(self):
+        transform = june_group_to_mp({"group_key": "company"})
+        record = {
+            "group_id": "acme",
+            "traits": '{"name": "Acme Corp"}',
+            "context": "{}",
+        }
+        result = transform(record)
+        assert result["$group_id"] == "acme"
+        assert result["$group_key"] == "company"
+
+
+class TestMixpanelReimport:
+    def test_export_format_to_import_format(self):
+        transform = mixpanel_events_to_mixpanel({})
+        record = {
+            "event_name": "Page View",
+            "properties": {"page": "/home", "$browser": "Chrome"},
+            "distinct_id": "user1",
+            "time": 1700000000,
+            "insert_id": "abc123",
+        }
+        result = transform(record)
+        assert result["event"] == "Page View"
+        assert result["properties"]["distinct_id"] == "user1"
+        assert result["properties"]["$insert_id"] == "abc123"
+        assert result["properties"]["time"] == 1700000000
+        assert result["properties"]["page"] == "/home"
+
+
+def _load_json_or_jsonl(path):
+    with open(path) as f:
+        content = f.read().strip()
+    try:
+        data = json.loads(content)
+        return data if isinstance(data, list) else [data]
+    except json.JSONDecodeError:
+        return [json.loads(line) for line in content.split("\n") if line.strip()]

--- a/tests/streaming/test_vendors.py
+++ b/tests/streaming/test_vendors.py
@@ -2,7 +2,6 @@
 
 import json
 import pytest
-from pathlib import Path
 
 from mixpanel_utils.streaming.vendors.amplitude import amp_events_to_mp, amp_user_to_mp, amp_group_to_mp
 from mixpanel_utils.streaming.vendors.heap import heap_events_to_mp, heap_user_to_mp
@@ -11,8 +10,6 @@ from mixpanel_utils.streaming.vendors.posthog import posthog_events_to_mp, posth
 from mixpanel_utils.streaming.vendors.mparticle import mparticle_events_to_mixpanel, mparticle_user_to_mixpanel
 from mixpanel_utils.streaming.vendors.june import june_events_to_mp, june_user_to_mp, june_group_to_mp
 from mixpanel_utils.streaming.vendors.mixpanel import mixpanel_events_to_mixpanel
-
-TEST_DATA = Path(__file__).parent.parent.parent / "SCRATCH_TEST_DATA"
 
 
 class TestAmplitude:
@@ -59,18 +56,6 @@ class TestAmplitude:
         result = transform({"user_properties": {}})
         assert result == {}
 
-    def test_real_data(self):
-        path = TEST_DATA / "amplitude" / "2023-04-10_1#0.json"
-        if not path.exists():
-            pytest.skip("Test data not available")
-        transform = amp_events_to_mp({"user_id": "user_id", "v2_compat": True})
-        with open(path) as f:
-            record = json.loads(f.readline())
-        result = transform(record)
-        assert result is not None
-        assert result["event"]
-        assert "$insert_id" in result["properties"]
-
 
 class TestHeap:
     def test_event_transform(self):
@@ -95,16 +80,6 @@ class TestHeap:
         }
         result = transform(record)
         assert result["$distinct_id"] == "user@example.com"
-
-    def test_real_data(self):
-        path = TEST_DATA / "heap" / "heap-events-ex.json"
-        if not path.exists():
-            pytest.skip("Test data not available")
-        transform = heap_events_to_mp({})
-        data = _load_json_or_jsonl(path)
-        result = transform(data[0])
-        assert result is not None
-        assert result.get("event")
 
 
 class TestGA4:
@@ -136,16 +111,6 @@ class TestGA4:
         }
         result = transform(record)
         assert "$insert_id" in result["properties"]
-
-    def test_real_data(self):
-        path = TEST_DATA / "ga4" / "ga4_sample.json"
-        if not path.exists():
-            pytest.skip("Test data not available")
-        transform = ga_events_to_mp({"time_conversion": "seconds"})
-        data = _load_json_or_jsonl(path)
-        result = transform(data[0])
-        assert result is not None
-        assert result.get("event")
 
 
 class TestPostHog:
@@ -215,15 +180,6 @@ class TestMParticle:
         assert result[0]["event"] == "Purchase"
         assert result[0]["properties"]["$user_id"] == "cust123"
 
-    def test_real_data(self):
-        path = TEST_DATA / "mparticle" / "sample_data.txt"
-        if not path.exists():
-            pytest.skip("Test data not available")
-        transform = mparticle_events_to_mixpanel({})
-        data = _load_json_or_jsonl(path)
-        result = transform(data[0])
-        assert isinstance(result, list)
-
 
 class TestJune:
     def test_event_transform(self):
@@ -283,13 +239,3 @@ class TestMixpanelReimport:
         assert result["properties"]["$insert_id"] == "abc123"
         assert result["properties"]["time"] == 1700000000
         assert result["properties"]["page"] == "/home"
-
-
-def _load_json_or_jsonl(path):
-    with open(path) as f:
-        content = f.read().strip()
-    try:
-        data = json.loads(content)
-        return data if isinstance(data, list) else [data]
-    except json.JSONDecodeError:
-        return [json.loads(line) for line in content.split("\n") if line.strip()]


### PR DESCRIPTION
## Streaming import/export + CLI

internal discussion: https://mixpanel.slack.com/archives/C04TJL0J0/p1774375065593449

This PR adds an async streaming pipeline and CLI to mixpanel-utils, inspired by my ["unofficial" mixpanel-import npm package](https://www.npmjs.com/package/mixpanel-import) ... they are all behind an optional extras install (`pip install mixpanel-utils[streaming]`).

### Why? 
Importing and exporting data is the most common customer use case for this module. Today, customers need to understand Mixpanel's exact event/profile format, write their own transforms, handle batching, deal with retries, and manage concurrency. For anyone coming from Amplitude, GA4, PostHog, or Heap, that means writing a custom migration script from scratch every time. That's silly, right? The module should handle it.

### How?
`mp.stream.import_events("./data.csv")` just works. Auto-detects format (JSONL, JSON, CSV, Parquet, gzip), auto-fixes common data issues, batches intelligently (by count and size), compresses, retries, and streams with concurrent connections. The same for exports and cross-project migrations. Seven built-in vendor transforms handle the field mapping for Amplitude, Heap, GA4, PostHog, mParticle, June, and re-imports of Mixpanel's own export format.

The CLI (`mixpanel-utils ./events.csv --type event --token TOKEN`) exposes the same functionality for users who don't want to write Python.

### Continuity
Since this is "new" functionality, this is how we kept it contained:

- Everything lives in `src/mixpanel_utils/streaming/`:  a self-contained subpackage with its own types, constants, I/O, transforms, and vendor modules. Zero changes to the existing sync codebase beyond adding a lazy .stream property.

- Lazy imports: from `mixpanel_utils import MixpanelUtils` does not pull in `httpx` or any streaming dependencies. They're only loaded when `.stream` is accessed.

- `from __future__ import annotations` on all streaming file;  preserves `python_requires='>=3'` so existing users on older Python are unaffected.

- Optional extras: `[streaming]`, `[streaming-gcs]`, `[streaming-s3]`, `[streaming-all]`. The base package stays dependency-free.

- Credentials inherit from the parent — `mp.stream.import_events()` uses the same service_account_username/password/project_id/token passed to `MixpanelUtils()`. No separate auth.

- Version bump is 3.0.0 → 3.1.0 (minor) — this is purely additive. No existing API is changed or removed.

### tldr;

- 9 async methods: `import_events`, `import_people`, `import_groups`, `export_events`, `export_people`, `export_groups`, `export_import_events`, `export_import_people`, `export_import_groups`
- CLI entry point: `mixpanel-utils`
- 71 new tests (128 total passing), all streaming tests use inline data for CI
- 3 sample scripts following existing patterns
- README updates with full API docs and CLI examples

<img width="258" height="750" alt="streaming-test-suite" src="https://github.com/user-attachments/assets/e3586f63-6974-41f3-a259-8f2a6ab90b1e" />
