### PR TITLE
Add GitHub Actions workflow to publish to PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04
+    environment: pypi
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install build dependencies
+        run: python -m pip install --upgrade pip build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Introduce a workflow that runs on published releases (tags) to build and publish the package to PyPI.

Before this will work, someone with PyPI admin access ( @jaredmixpanel @dongjae93 ) to mixpanel-utils needs to do the one-time Trusted Publisher setup:

  1. Go to the PyPI project settings → Publishing
  2. Add trusted publisher: owner mixpanel, repo mixpanel-utils, workflow publish.yml, environment pypi
  
 - Current version [3.0.0](https://github.com/mixpanel/mixpanel-utils/commit/5a6cb29dd994f7caa6da7b18b2b01b8d363c184b) that deprecates API Secret is not published in PyPI.

CC: @tylerjroach 
  
  