### PR TITLE
chore: standardize release process

### DIFF
--- a/.github/modules.json
+++ b/.github/modules.json
@@ -1,0 +1,10 @@
+{
+  "analytics": {
+    "tag_prefix": "v",
+    "setup_py": "setup.py",
+    "version_files": [],
+    "changelog": "CHANGELOG.md",
+    "readme": "README.md",
+    "package_name": "mixpanel-utils"
+  }
+}

--- a/.github/scripts/generate-changelog.sh
+++ b/.github/scripts/generate-changelog.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+set -euo pipefail
+
+MODULE="$1"
+VERSION_LABEL="$2"
+REPO_URL="$3"
+END_REF="${4:-HEAD}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MODULES_JSON="$SCRIPT_DIR/../modules.json"
+
+TAG_PREFIX=$(jq -e -r --arg m "$MODULE" '.[$m].tag_prefix' "$MODULES_JSON") || {
+  echo "Unknown module: $MODULE. Valid modules: $(jq -r 'keys | join(", ")' "$MODULES_JSON")" >&2
+  exit 1
+}
+TAG_GLOB="${TAG_PREFIX}*"
+
+PREVIOUS_TAG=$(git tag --sort=-creatordate --list "$TAG_GLOB" | head -1 || true)
+
+if [ -z "$PREVIOUS_TAG" ]; then
+  RANGE="$END_REF"
+else
+  RANGE="${PREVIOUS_TAG}..${END_REF}"
+fi
+
+DATE=$(date +%Y-%m-%d)
+SAFE_URL=$(printf '%s' "$REPO_URL" | sed 's|[&/\]|\\&|g')
+
+declare -a FEATURES=()
+declare -a FIXES=()
+declare -a CHORES=()
+
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  MSG=$(echo "$line" | cut -d' ' -f2-)
+
+  if [[ "$MSG" =~ ^(feat|fix|chore)\((${MODULE}|all)\):\ (.+) ]]; then
+    TYPE="${BASH_REMATCH[1]}"
+    DESC="${BASH_REMATCH[3]}"
+
+    DESC=$(echo "$DESC" | sed -E "s|\(#([0-9]+)\)|([#\1](${SAFE_URL}/pull/\1))|g")
+
+    case "$TYPE" in
+      feat) FEATURES+=("$DESC") ;;
+      fix) FIXES+=("$DESC") ;;
+      chore) CHORES+=("$DESC") ;;
+    esac
+  fi
+done < <(git log --oneline "$RANGE")
+
+echo "## [${VERSION_LABEL}](${REPO_URL}/tree/${VERSION_LABEL}) (${DATE})"
+echo ""
+
+if [ ${#FEATURES[@]} -gt 0 ]; then
+  echo "### Features"
+  for entry in "${FEATURES[@]}"; do
+    echo "- ${entry}"
+  done
+  echo ""
+fi
+
+if [ ${#FIXES[@]} -gt 0 ]; then
+  echo "### Fixes"
+  for entry in "${FIXES[@]}"; do
+    echo "- ${entry}"
+  done
+  echo ""
+fi
+
+if [ ${#CHORES[@]} -gt 0 ]; then
+  echo "### Chores"
+  for entry in "${CHORES[@]}"; do
+    echo "- ${entry}"
+  done
+  echo ""
+fi
+
+if [ -n "$PREVIOUS_TAG" ]; then
+  echo "[Full Changelog](${REPO_URL}/compare/${PREVIOUS_TAG}...${VERSION_LABEL})"
+fi

--- a/.github/scripts/generate-changelog.sh
+++ b/.github/scripts/generate-changelog.sh
@@ -34,17 +34,24 @@ while IFS= read -r line; do
   [ -z "$line" ] && continue
   MSG=$(echo "$line" | cut -d' ' -f2-)
 
-  if [[ "$MSG" =~ ^(feat|fix|chore)\((${MODULE}|all)\):\ (.+) ]]; then
+  # feat / fix: include whether bare, scoped to our module, or scoped to
+  # `all` (cross-cutting changes that appear in every module's changelog).
+  # chore: include only when explicitly scoped to our module or `all` —
+  # bare `chore:` is the convention for changes intentionally hidden from
+  # the changelog (release prep PRs, CI tweaks, lockfile bumps, internal
+  # docs).
+  if [[ "$MSG" =~ ^(feat|fix)(\((${MODULE}|all)\))?:\ (.+) ]]; then
     TYPE="${BASH_REMATCH[1]}"
-    DESC="${BASH_REMATCH[3]}"
-
+    DESC="${BASH_REMATCH[4]}"
     DESC=$(echo "$DESC" | sed -E "s|\(#([0-9]+)\)|([#\1](${SAFE_URL}/pull/\1))|g")
-
     case "$TYPE" in
       feat) FEATURES+=("$DESC") ;;
       fix) FIXES+=("$DESC") ;;
-      chore) CHORES+=("$DESC") ;;
     esac
+  elif [[ "$MSG" =~ ^chore\((${MODULE}|all)\):\ (.+) ]]; then
+    DESC="${BASH_REMATCH[2]}"
+    DESC=$(echo "$DESC" | sed -E "s|\(#([0-9]+)\)|([#\1](${SAFE_URL}/pull/\1))|g")
+    CHORES+=("$DESC")
   fi
 done < <(git log --oneline "$RANGE")
 

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -23,8 +23,10 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           MODULE_LIST=$(jq -r 'keys | join("|")' .github/modules.json)
-          # Scope is optional. Bare or scoped to a known module both pass.
-          MAIN_PATTERN="^(feat|fix|chore)(\((${MODULE_LIST})\))?: .+"
+          # Scope is optional. Bare, scoped to a known module, or scoped to
+          # `all` (cross-cutting changes that appear in every module's
+          # changelog) all pass.
+          MAIN_PATTERN="^(feat|fix|chore)(\((${MODULE_LIST}|all)\))?: .+"
           RELEASE_PATTERN="^release: .+"
 
           if [[ "$PR_TITLE" =~ $MAIN_PATTERN ]] || [[ "$PR_TITLE" =~ $RELEASE_PATTERN ]]; then
@@ -40,10 +42,10 @@ jobs:
           echo "  feat: description"
           echo "  fix: description"
           echo "  chore: description"
-          echo "  feat(<module>): description"
-          echo "  fix(<module>): description"
-          echo "  chore(<module>): description"
+          echo "  feat(<module>|all): description"
+          echo "  fix(<module>|all): description"
+          echo "  chore(<module>|all): description"
           echo "  release: description"
           echo ""
-          echo "Valid modules: ${MODULE_LIST//|/, }"
+          echo "Valid scopes: ${MODULE_LIST//|/, }, all"
           exit 1

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,49 @@
+name: PR Title Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  check-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          sparse-checkout: .github/modules.json
+          sparse-checkout-cone-mode: false
+
+      - name: Check PR title format
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          MODULE_LIST=$(jq -r 'keys | join("|")' .github/modules.json)
+          # Scope is optional. Bare or scoped to a known module both pass.
+          MAIN_PATTERN="^(feat|fix|chore)(\((${MODULE_LIST})\))?: .+"
+          RELEASE_PATTERN="^release: .+"
+
+          if [[ "$PR_TITLE" =~ $MAIN_PATTERN ]] || [[ "$PR_TITLE" =~ $RELEASE_PATTERN ]]; then
+            echo "PR title is valid: $PR_TITLE"
+            exit 0
+          fi
+
+          echo "PR title does not match the required format."
+          echo ""
+          echo "  Got: $PR_TITLE"
+          echo ""
+          echo "Expected one of:"
+          echo "  feat: description"
+          echo "  fix: description"
+          echo "  chore: description"
+          echo "  feat(<module>): description"
+          echo "  fix(<module>): description"
+          echo "  chore(<module>): description"
+          echo "  release: description"
+          echo ""
+          echo "Valid modules: ${MODULE_LIST//|/, }"
+          exit 1

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,198 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      module:
+        description: 'Module to release (must match a key in .github/modules.json)'
+        required: true
+        type: string
+      version:
+        description: 'Release version (e.g., 3.1.0 or 3.1.0-beta.1)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: prepare-release-${{ inputs.module }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: "Prepare ${{ inputs.module }} ${{ inputs.version }}"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate inputs
+        env:
+          MODULE: ${{ inputs.module }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Invalid version format: $VERSION"
+            exit 1
+          fi
+          jq -e --arg m "$MODULE" '.[$m]' .github/modules.json > /dev/null || {
+            echo "::error::Unknown module '$MODULE'. Valid modules: $(jq -r 'keys | join(", ")' .github/modules.json)"
+            exit 1
+          }
+
+      - name: Resolve module config
+        id: config
+        env:
+          MODULE: ${{ inputs.module }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          MODULE_CONFIG=$(jq -e --arg m "$MODULE" '.[$m]' .github/modules.json)
+
+          TAG_PREFIX=$(echo "$MODULE_CONFIG" | jq -r '.tag_prefix')
+          {
+            echo "tag=${TAG_PREFIX}${VERSION}"
+            echo "setup_py=$(echo "$MODULE_CONFIG" | jq -r '.setup_py')"
+            echo "changelog=$(echo "$MODULE_CONFIG" | jq -r '.changelog')"
+            echo "readme=$(echo "$MODULE_CONFIG" | jq -r '.readme')"
+            echo "package_name=$(echo "$MODULE_CONFIG" | jq -r '.package_name')"
+            echo "branch=release/${MODULE}/${VERSION}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Validate version not already released
+        env:
+          TAG: ${{ steps.config.outputs.tag }}
+        run: |
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "::error::Tag $TAG already exists on the remote"
+            exit 1
+          fi
+
+      - name: Clean up existing release branch and PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.config.outputs.branch }}
+        run: |
+          EXISTING_PR=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null || true)
+          if [[ -n "$EXISTING_PR" ]]; then
+            echo "Closing existing PR #$EXISTING_PR and deleting branch"
+            gh pr close "$EXISTING_PR" --delete-branch
+          elif git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "Deleting orphaned branch $BRANCH"
+            git push origin --delete "$BRANCH"
+          fi
+
+      - name: Create release branch
+        env:
+          BRANCH: ${{ steps.config.outputs.branch }}
+        run: git checkout -b "$BRANCH"
+
+      - name: Bump version in setup.py
+        env:
+          VERSION: ${{ inputs.version }}
+          SETUP_PY: ${{ steps.config.outputs.setup_py }}
+        run: |
+          OLD_VERSION=$(grep -E "version=['\"][^'\"]*['\"]" "$SETUP_PY" | head -1 | sed -E "s/.*version=['\"]([^'\"]*)['\"].*/\1/")
+          if [ -z "$OLD_VERSION" ]; then
+            echo "::error::Could not read current version from $SETUP_PY"
+            exit 1
+          fi
+          echo "Bumping ${OLD_VERSION} -> ${VERSION}"
+
+          sed -i -E "s/version=['\"][^'\"]*['\"]/version='${VERSION}'/" "$SETUP_PY"
+
+          NEW_VERSION=$(grep -E "version=['\"][^'\"]*['\"]" "$SETUP_PY" | head -1 | sed -E "s/.*version=['\"]([^'\"]*)['\"].*/\1/")
+          if [ "$NEW_VERSION" != "$VERSION" ]; then
+            echo "::error::Version bump failed; expected '$VERSION', got '$NEW_VERSION'"
+            exit 1
+          fi
+
+      - name: Update README version header
+        env:
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+          TAG: ${{ steps.config.outputs.tag }}
+          README: ${{ steps.config.outputs.readme }}
+        run: |
+          DATE=$(date +"%B %d, %Y")
+          # Replace the version header line.
+          # The `1,/pat/` address range bounds the substitution to lines from
+          # the start of the file through the first match, so a README that
+          # accidentally contains a second matching line is left untouched.
+          sed -i -E \
+            "1,/^##### _.*_ - \[.*\]\(.*\)\$/ s|^##### _.*_ - \[.*\]\(.*\)\$|##### _${DATE}_ - [${TAG}](${REPO_URL}/releases/tag/${TAG})|" \
+            "$README"
+
+      - name: Generate changelog
+        env:
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+          MODULE: ${{ inputs.module }}
+          TAG: ${{ steps.config.outputs.tag }}
+          CHANGELOG_FILE: ${{ steps.config.outputs.changelog }}
+        run: |
+          CHANGELOG=$(.github/scripts/generate-changelog.sh \
+            "$MODULE" "$TAG" "$REPO_URL" HEAD)
+
+          if [ -f "$CHANGELOG_FILE" ]; then
+            {
+              printf '# Changelog\n\n%s\n' "$CHANGELOG"
+              sed '1{/^# Changelog$/d;}' "$CHANGELOG_FILE"
+            } > CHANGELOG.new.md
+            mv CHANGELOG.new.md "$CHANGELOG_FILE"
+          else
+            printf '# Changelog\n\n%s\n' "$CHANGELOG" > "$CHANGELOG_FILE"
+          fi
+
+      - name: Commit and push
+        env:
+          MODULE: ${{ inputs.module }}
+          VERSION: ${{ inputs.version }}
+          BRANCH: ${{ steps.config.outputs.branch }}
+          SETUP_PY: ${{ steps.config.outputs.setup_py }}
+          CHANGELOG_FILE: ${{ steps.config.outputs.changelog }}
+          README: ${{ steps.config.outputs.readme }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "$SETUP_PY" "$CHANGELOG_FILE" "$README"
+          git commit -m "release: prepare ${MODULE} ${VERSION}"
+          git push origin "$BRANCH"
+
+      - name: Create pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MODULE: ${{ inputs.module }}
+          VERSION: ${{ inputs.version }}
+          TAG: ${{ steps.config.outputs.tag }}
+          SETUP_PY: ${{ steps.config.outputs.setup_py }}
+          CHANGELOG_FILE: ${{ steps.config.outputs.changelog }}
+          README: ${{ steps.config.outputs.readme }}
+          BRANCH: ${{ steps.config.outputs.branch }}
+        run: |
+          gh pr create \
+            --title "release: prepare ${MODULE} ${VERSION}" \
+            --body "$(cat <<EOF
+          ## Release ${MODULE} ${VERSION}
+
+          This PR prepares the ${MODULE} module for release.
+
+          ### Changes
+          - Bumps \`version\` to \`${VERSION}\` in \`${SETUP_PY}\`
+          - Updates \`${CHANGELOG_FILE}\` with a new section since the last \`${TAG%${VERSION}}*\` tag
+          - Updates \`${README}\` version header
+
+          ### After merging
+          1. Push tag \`${TAG}\` from the merge commit on \`master\` to trigger the publish workflow:
+             \`\`\`
+             git checkout master && git pull
+             git tag ${TAG}
+             git push origin ${TAG}
+             \`\`\`
+          2. The publish workflow creates a draft GitHub release and publishes to PyPI. Review and publish the GitHub release after the workflow finishes.
+          EOF
+          )" \
+            --base master \
+            --head "$BRANCH"

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           MODULE=$(jq -r --arg t "$TAG" '
             to_entries
-            | map(select($t | startswith(.value.tag_prefix)))
+            | map(select(.value.tag_prefix as $p | $t | startswith($p)))
             | max_by(.value.tag_prefix | length)
             | .key // empty
           ' .github/modules.json)

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -128,24 +128,20 @@ jobs:
           TAG: ${{ github.ref_name }}
           CHANGELOG: ${{ steps.module.outputs.changelog }}
         run: |
-          # Match the section header `## [${TAG}](...)` and stop at the next `## ` header.
-          # Falls back to a placeholder if no matching section is found.
-          python3 - <<'PY' > release_notes.md
-          import os, re, sys
-          tag = os.environ["TAG"]
-          changelog_path = os.environ["CHANGELOG"]
-          try:
-              content = open(changelog_path).read()
-          except FileNotFoundError:
-              print(f"Release {tag}")
-              sys.exit(0)
-          pattern = r'^## \[' + re.escape(tag) + r'\].*?\n(.*?)(?=^## |\Z)'
-          match = re.search(pattern, content, re.DOTALL | re.MULTILINE)
-          if match:
-              print(match.group(1).strip())
-          else:
-              print(f"Release {tag}")
-          PY
+          # Extract this tag's section from CHANGELOG.md via a sed range.
+          # The address `\@^## \[TAG\]@,\@^## \[@` selects from the version
+          # header through the next `## [` line; the inner block deletes
+          # both markers and prints the body. sed range patterns don't test
+          # the end pattern against the start line, so the start doesn't
+          # self-terminate. `\@...@` switches the address delimiter from
+          # `/` to `@` so tags containing `/` (e.g. `openfeature/v0.1.0`)
+          # don't conflict with the default `/`. Mirrors the deployed
+          # mixpanel-android extraction logic. Falls back to a placeholder
+          # if the section is missing or empty.
+          sed -n '\@^## \['"${TAG}"'\]@,\@^## \[@{\@^## \['"${TAG}"'\]@d;\@^## \[@d;p;}' "$CHANGELOG" 2>/dev/null > release_notes.md || true
+          if [ ! -s release_notes.md ]; then
+            echo "Release $TAG" > release_notes.md
+          fi
           echo "--- release_notes.md ---"
           cat release_notes.md
 

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -1,0 +1,189 @@
+name: Publish Release to PyPI
+
+# Tag-triggered: PyPI trusted publishing requires the publish to come from a
+# workflow run triggered by a tag-push matching the pattern configured in
+# the project's PyPI "Trusted Publishers" entry. Add new tag prefixes
+# here as additional modules are added to .github/modules.json (e.g. `- 'foo-v*'`).
+on:
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: pypi-publish
+  cancel-in-progress: false
+
+permissions:
+  contents: write   # create the draft GitHub release
+  id-token: write   # OIDC for PyPI trusted publishing
+
+jobs:
+  publish:
+    name: "Publish ${{ github.ref_name }} to PyPI"
+    runs-on: ubuntu-latest
+    environment: release
+    timeout-minutes: 30
+
+    # One-time PyPI / GitHub Environment / tag ruleset setup is required.
+    # The `environment:` name above must match what PyPI's Trusted Publishers
+    # entry is configured to require.
+
+    steps:
+      - name: Checkout tagged commit
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Resolve module from tag
+        id: module
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          MODULE=$(jq -r --arg t "$TAG" '
+            to_entries
+            | map(select($t | startswith(.value.tag_prefix)))
+            | max_by(.value.tag_prefix | length)
+            | .key // empty
+          ' .github/modules.json)
+
+          if [ -z "$MODULE" ]; then
+            echo "::error::Tag '$TAG' does not match any module tag_prefix in .github/modules.json"
+            exit 1
+          fi
+
+          MODULE_CONFIG=$(jq -e --arg m "$MODULE" '.[$m]' .github/modules.json)
+          TAG_PREFIX=$(echo "$MODULE_CONFIG" | jq -r '.tag_prefix')
+          VERSION="${TAG#${TAG_PREFIX}}"
+
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Version '$VERSION' (from tag '$TAG') is not a valid semver"
+            exit 1
+          fi
+
+          {
+            echo "module=$MODULE"
+            echo "version=$VERSION"
+            echo "tag_prefix=$TAG_PREFIX"
+            echo "setup_py=$(echo "$MODULE_CONFIG" | jq -r '.setup_py')"
+            echo "changelog=$(echo "$MODULE_CONFIG" | jq -r '.changelog')"
+            echo "package_name=$(echo "$MODULE_CONFIG" | jq -r '.package_name')"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Resolved tag '$TAG' -> module '$MODULE', version '$VERSION'"
+
+      - name: Verify tag commit is on master
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          git fetch origin master
+          TAG_SHA=$(git rev-parse HEAD)
+          if ! git merge-base --is-ancestor "$TAG_SHA" origin/master; then
+            echo "::error::Tag '$TAG' ($TAG_SHA) is not an ancestor of origin/master."
+            echo "Tags must be pushed from a commit on the master branch."
+            exit 1
+          fi
+
+      - name: Validate setup.py version matches tag
+        env:
+          VERSION: ${{ steps.module.outputs.version }}
+          SETUP_PY: ${{ steps.module.outputs.setup_py }}
+        run: |
+          PKG_VERSION=$(grep -E "version=['\"][^'\"]*['\"]" "$SETUP_PY" | head -1 | sed -E "s/.*version=['\"]([^'\"]*)['\"].*/\1/")
+          if [ -z "$PKG_VERSION" ]; then
+            echo "::error::Could not read version from $SETUP_PY"
+            exit 1
+          fi
+          if [ "$VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version '$VERSION' does not match $SETUP_PY version '$PKG_VERSION'"
+            exit 1
+          fi
+          echo "Version confirmed: $PKG_VERSION"
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: '3.12'
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade build twine
+
+      - name: Install package and test dependencies
+        run: |
+          pip install -e .
+          pip install pytest pytest-cov
+
+      - name: Run tests
+        run: pytest
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Check distributions
+        run: python -m twine check dist/*
+
+      - name: Extract changelog section for tag
+        env:
+          TAG: ${{ github.ref_name }}
+          CHANGELOG: ${{ steps.module.outputs.changelog }}
+        run: |
+          # Match the section header `## [${TAG}](...)` and stop at the next `## ` header.
+          # Falls back to a placeholder if no matching section is found.
+          python3 - <<'PY' > release_notes.md
+          import os, re, sys
+          tag = os.environ["TAG"]
+          changelog_path = os.environ["CHANGELOG"]
+          try:
+              content = open(changelog_path).read()
+          except FileNotFoundError:
+              print(f"Release {tag}")
+              sys.exit(0)
+          pattern = r'^## \[' + re.escape(tag) + r'\].*?\n(.*?)(?=^## |\Z)'
+          match = re.search(pattern, content, re.DOTALL | re.MULTILINE)
+          if match:
+              print(match.group(1).strip())
+          else:
+              print(f"Release {tag}")
+          PY
+          echo "--- release_notes.md ---"
+          cat release_notes.md
+
+      - name: Create draft GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          # Idempotent: if a draft release for this tag already exists, leave it alone.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "GitHub release for $TAG already exists; skipping creation"
+          else
+            gh release create "$TAG" \
+              --draft \
+              --title "$TAG" \
+              --notes-file release_notes.md
+          fi
+
+      # Publish last — PyPI uploads are irreversible (yanking is possible but
+      # files cannot be re-uploaded under the same version). The draft GitHub
+      # release acts as the human gate via the `release` environment's required
+      # reviewer setting.
+      - name: Publish to PyPI
+        run: python -m twine upload --skip-existing dist/*
+
+      - name: Summary
+        env:
+          MODULE: ${{ steps.module.outputs.module }}
+          VERSION: ${{ steps.module.outputs.version }}
+          PACKAGE_NAME: ${{ steps.module.outputs.package_name }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          {
+            echo "## ${MODULE} ${VERSION} published"
+            echo ""
+            echo "- [PyPI](https://pypi.org/project/${PACKAGE_NAME}/${VERSION}/)"
+            echo "- [Draft GitHub Release](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${TAG})"
+            echo ""
+            echo "### Next step"
+            echo "Review the draft GitHub release and click **Publish release** to make it live."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Mixpanel-utils Module
 
+##### _May 12, 2026_ - [v3.0.0](https://github.com/mixpanel/mixpanel-utils/releases/tag/v3.0.0)
+
 ### Please note: From v2.0 this module supports Python 3 only. If you require Python 2 use the older mixpanel_api v1.6.5.
 
 ### Table of Contents


### PR DESCRIPTION
## Summary

Standardizes this repo's release process to match the rest of the Mixpanel SDK fleet, per the [SDK Release Process Standardization Effort](https://www.notion.so/mxpnl/SDK-Release-Process-Standardization-Effort-348e0ba925628029af63c779caa835f9).

After merge, releases follow a uniform two-step ceremony:

1. Run the **Prepare Release** workflow (`prepare-release.yml`) — opens a release PR with the version bump, changelog section, and README header line updated.
2. Push the release tag — `release-pypi.yml` validates, gates on the `release` GitHub environment for human approval, and publishes (where applicable for this ecosystem).

## What's added

- `.github/modules.json` — single source of truth for module config (paths, tag prefixes, package names)
- `.github/workflows/prepare-release.yml` — manual dispatch, opens release PR
- `.github/workflows/release-pypi.yml` — tag-triggered publish workflow
- `.github/workflows/pr-title-check.yml` — conventional-commit enforcement (regex built from `modules.json`)
- `.github/scripts/generate-changelog.sh` — shared changelog generator (verbatim from mixpanel-android)
- README version-header line on each module's README, seeded with the current latest tag
- `CHANGELOG.md` per module where missing
- Single module `analytics` (`mixpanel-utils` on PyPI)
- This is the first release pipeline ever for this repo (no existing tags) — the first release will be tagged `v3.0.0` (matching the version currently in `setup.py`) or whichever version you choose to bump to
- PyPI Trusted Publisher entry required — see runbook

## How releases work after this lands

Full ceremony, one-time setup, and PR title conventions: **[Python [PIP] Release Runbook](https://www.notion.so/mxpnl/Python-PIP-Release-Runbook-35ee0ba9256280dbbe32c9cc26332bde)**

## One-time setup before the first release

The runbook lists the full setup. The work that requires repo-admin access (cannot be done in this PR):

- Create a GitHub Environment named `release` with required reviewer(s)
- Branch protection on the default branch (require PR review + the new `Validate PR title` check)
- Tag rulesets (restrict creation/update/deletion of release tags)
- Workflow permissions: enable `Read and write permissions` and `Allow GitHub Actions to create and approve pull requests` (needed by `prepare-release.yml`'s `gh pr create`)

## Notes

- This is a **WIP** draft to be reviewed alongside the equivalent PRs in the other SDK repos. The Flutter and React Native ports are tracked at mixpanel-flutter#238, mixpanel-flutter-session-replay#30, mixpanel-react-native#408, mixpanel-react-native-session-replay#64.
- This PR does not change any source code or build behavior — only adds release infrastructure.
- The standardization commit is followed by a small `fix:` commit correcting a jq tag-resolution snippet (the same bug exists in the WIP Flutter/RN PRs and should be back-ported there).